### PR TITLE
Don't show pause screen when already showing end game screen

### DIFF
--- a/android/src/com/serwylo/beatgame/AndroidLauncher.java
+++ b/android/src/com/serwylo/beatgame/AndroidLauncher.java
@@ -10,6 +10,7 @@ public class AndroidLauncher extends AndroidApplication {
 	protected void onCreate (Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		AndroidApplicationConfiguration config = new AndroidApplicationConfiguration();
+		config.useImmersiveMode = true;
 		initialize(new BeatFeetGame(new AndroidPlatformListener(this), true), config);
 	}
 }


### PR DESCRIPTION
Also uses Androids "immersive mode" to hide the system menu. Think this is a good option for Android games. It is always there if you need it, but hidden by default.

Fixes #93.