### PR TITLE
Don't accidentally move vertically when shaking.

### DIFF
--- a/core/src/com/serwylo/beatgame/HUD.kt
+++ b/core/src/com/serwylo/beatgame/HUD.kt
@@ -265,7 +265,7 @@ class DiscreteProgressBar(
                 sequence(
                     moveBy(shakeDistance / 2, 0f, shakeTime),
                     moveBy( - shakeDistance, 0f, shakeTime * 2),
-                    Actions.moveBy(shakeDistance / 2, shakeTime)
+                    moveBy(shakeDistance / 2, 0f, shakeTime)
                 )
             )
         )


### PR DESCRIPTION
Was accidentally moving vertically by 0.03f pixels, instead of moving horizontally for 0.03f seconds.
As an added bonus, it shakes in a slightly smoother way now and looks a little less jarry.

Fixes #89.