### PR TITLE
More appropriate fallback locale to fix #112.

### DIFF
--- a/core/src/com/serwylo/beatgame/Assets.kt
+++ b/core/src/com/serwylo/beatgame/Assets.kt
@@ -410,7 +410,7 @@ class Assets(private val locale: Locale) {
                 systemLocale
             } else {
                 Gdx.app.error(TAG, "Unsupported locale: $systemLocale, falling back to English.")
-                Locale.ENGLISH
+                Locale.ROOT
             }
         }
 


### PR DESCRIPTION
Previously, fell back to `Locale.ENGLISH` when a properties file exists for a language
but for which there are no fonts or RTL support. This was problematic, because libgdx
uses this as a way to search for a properties file as a fallback. When using `Locale.ENGLISH`,
that means it looks for `messages_en.properties`, but that file doesn't exist.

By instead searching for `Locale.ROOT`, it correctly picks up `messages.properties` instead, and
therefore we show Engish as a fallback for unsupported languages.

This fixes the Persian language (and others) who were trying to render `message_fa.properties`
with regular Latin characters, which results in the unsupported glyph being shown.