### PR TITLE
Enable Bulgarian translation, bump for release.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.serwylo.beatgame"
         minSdkVersion 14
         targetSdkVersion 30
-        versionCode 15
-        versionName "0.12.2"
+        versionCode 16
+        versionName "0.12.3"
     }
     buildTypes {
         release {

--- a/core/src/com/serwylo/beatgame/Assets.kt
+++ b/core/src/com/serwylo/beatgame/Assets.kt
@@ -368,6 +368,7 @@ class Assets(private val locale: Locale) {
          * accomplish unfortunately.
          */
         private val supportedLocales = setOf(
+            "bg",
             // "bn", // Glyphs are currently unsupported.
             "de",
             "en",
@@ -388,7 +389,7 @@ class Assets(private val locale: Locale) {
 
         private val notoLocales = setOf(
             "lt", // The characters Ž, ę, š, and perhaps others are not supported with Kenney fonts.
-            "vi", "ru", "pl", "mk"
+            "bg", "vi", "ru", "pl", "mk"
         )
 
         private fun isLocaleSupported(locale: Locale): Boolean {

--- a/fastlane/metadata/android/en-US/changelogs/16.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16.txt
@@ -1,0 +1,10 @@
+👍 More translations!
+
+* New:
+ - Bulgarian (thanks to YavBav09)
+ - Lithuanian (thanks to g)
+
+* Fixed:
+ - Persian (thanks to doondoondoondoon for reporting the issue)
+
+Support further development via GitHub Sponsors or Liberapay.


### PR DESCRIPTION
Seems to be supported well by Noto, so a straightforward addition.
Furthermore, the sprites for these characters have already been added,
either because the `messages_bg.properties` was already there, or because
it uses the same letters as Macedonian. Either way, no additional
generation of fonts required.

