### PR TITLE
 increase double jump threshold + bump for release v0.13.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.serwylo.beatgame"
         minSdkVersion 14
         targetSdkVersion 30
-        versionCode 18
-        versionName "0.12.5"
+        versionCode 19
+        versionName "0.13.0"
     }
     buildTypes {
         release {

--- a/core/src/com/serwylo/beatgame/audio/features/World.kt
+++ b/core/src/com/serwylo/beatgame/audio/features/World.kt
@@ -1,6 +1,5 @@
 package com.serwylo.beatgame.audio.features
 
-import com.badlogic.gdx.audio.Music
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.math.Vector2
 import com.serwylo.beatgame.levels.Level

--- a/core/src/com/serwylo/beatgame/entities/Player.kt
+++ b/core/src/com/serwylo/beatgame/entities/Player.kt
@@ -35,6 +35,7 @@ class Player(
     private var jumpCount = 0
 
     private val textureJump = sprites.character_a_jump
+    private val textureJump2 = sprites.character_a_duck
     private val textureHit = sprites.character_a_hit
     private val walkAnimation: Animation<TextureRegion> = Animation(0.2f, sprites.character_a_walk)
     private val deathAnimation = Animation(
@@ -114,7 +115,11 @@ class Player(
             }
         }
 
-        return textureJump
+        return if (jumpCount == 2) {
+            textureJump2
+        } else {
+            textureJump
+        }
 
     }
 
@@ -272,7 +277,7 @@ class Player(
          * Only allow double jumps when you are close to the top of your first jump. Seems to
          * offer a nice experience.
          */
-        const val DOUBLE_JUMP_THRESHOLD = 6f
+        const val DOUBLE_JUMP_THRESHOLD = 10f
 
         const val SHIELD_INITIAL_AMOUNT = 40
         const val SHIELD_MAX_AMOUNT = 100

--- a/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
+++ b/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
@@ -32,11 +32,25 @@ fun loadAchievementsForLevel(level: Level): List<AchievementType> {
 
 fun loadAllAchievements(): List<Achievement> {
     return loadPersistedAchievements().achievements.map { persisted ->
-        Achievement(
+        val level: Level? = try {
+            Levels.bySong(persisted.levelId)
+        } catch(exception: Exception) {
+            // For development purposes, sometimes we find ourselves installing newer versions
+            // with different levels, then going back to old versions. It is helpful without having
+            // to fully uninstall to delete all achievements, so we jsut ignore it.
+            Gdx.app.error("AchievementsIO", "Error loading level ${persisted.levelId}, but will just exclude this achievement.", exception)
+            null
+        }
+
+        if (level == null) {
+            null
+        } else {
+            Achievement(
                 allAchievements.find { it.id == persisted.achievementId }!!,
-                Levels.bySong(persisted.levelId)
-        )
-    }
+                level,
+            )
+        }
+    }.filterNotNull()
 }
 
 private fun loadPersistedAchievements(): PersistedAchievements {

--- a/core/src/com/serwylo/beatgame/screens/PlatformGameScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/PlatformGameScreen.kt
@@ -258,11 +258,11 @@ class PlatformGameScreen(
 
     private fun processInput() {
         if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE) || Gdx.input.isButtonJustPressed(Input.Buttons.LEFT)) {
+            // TODO: Move this to the input procesesor instead. Unlikely that we need both of these
+            //       ways of listening to input.
             if (state == State.PENDING) {
                 state = State.WARMING_UP
                 startTime = Globals.animationTimer
-            } else if (state == State.PLAYING || state == State.WARMING_UP) {
-                player.performJump()
             }
         }
     }

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -1,0 +1,6 @@
+🦘 More generous double jumps.
+
+ * Allow the second jump a greater time after the first jump.
+ * Show a different image for the second jump to remind you that you've used the second jump.
+
+Thanks to those who provided feedback regarding this on GitHub.


### PR DESCRIPTION
Be more generous with double jump thresholds, and also show a different sprite when on your second jump.

Fixes #116.