### PR TITLE
New levels loaded from the internet + bump for release v0.14.0

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/android/assets/i18n/messages.properties
+++ b/android/assets/i18n/messages.properties
@@ -51,7 +51,7 @@ level-select.more-coming-soon.suggest-a-song=Suggest a song
 loading-screen.loading=Loading
 loading-screen.downloading-song=Downloading soundtrack
 loading-screen.downloading-level=Downloading level
-loading-screen.generating-buildings=Generating buildings
+loading-screen.analysing-mp3=Analysing song: {0}
 loading-screen.best=Best
 loading-screen.custom-song-warning=Please be patient, it may take some time when analysing your song for the first time...
 

--- a/android/assets/i18n/messages.properties
+++ b/android/assets/i18n/messages.properties
@@ -51,7 +51,7 @@ level-select.more-coming-soon.suggest-a-song=Suggest a song
 loading-screen.loading=Loading
 loading-screen.downloading-song=Downloading soundtrack
 loading-screen.downloading-level=Downloading level
-loading-screen.analysing-mp3=Analysing song: {0}
+loading-screen.analysing-mp3=Analysing your song:
 loading-screen.best=Best
 loading-screen.custom-song-warning=Please be patient, it may take some time when analysing your song for the first time...
 

--- a/android/assets/i18n/messages.properties
+++ b/android/assets/i18n/messages.properties
@@ -55,6 +55,14 @@ loading-screen.analysing-mp3=Analysing your song:
 loading-screen.best=Best
 loading-screen.custom-song-warning=Please be patient, it may take some time when analysing your song for the first time...
 
+error.title=Error
+error.message.downloading-list-of-levels=Unable to check for new levels.\nAre you connected to the internet?
+error.message.downloading-level-data=Unable to download the song for this level.\nAre you connected to the internet?
+error.try-again=Try again
+error.show-details=Show details
+error.report.via-github=Report via GitHub
+error.report.via-email=Report via Email
+
 worlds.the-original=The Original
 levels.the-laundry-room=The Laundry Room
 levels.the-courtyard=The Courtyard

--- a/android/assets/i18n/messages.properties
+++ b/android/assets/i18n/messages.properties
@@ -48,6 +48,7 @@ loading-screen.loading=Loading
 loading-screen.best=Best
 loading-screen.custom-song-warning=Please be patient, it may take some time when analysing your song for the first time...
 
+worlds.the-original=The Original
 levels.the-laundry-room=The Laundry Room
 levels.the-courtyard=The Courtyard
 levels.maintenance=Maintenance

--- a/android/assets/i18n/messages.properties
+++ b/android/assets/i18n/messages.properties
@@ -43,8 +43,15 @@ custom-songs.copy-folder=Copy folder path
 custom-songs.view-folder=Open folder
 
 level-select.title=Level Select
+level-select.more-coming-soon.title=More coming soon
+level-select.more-coming-soon.ask-for-recommendations=Have any recommendations for great, freely licensed music? Suggest it on GitHub.
+level-select.more-coming-soon.when-we-find-time=When we find the time to add more songs, we'll make sure to check out the list of suggestions.
+level-select.more-coming-soon.suggest-a-song=Suggest a song
 
 loading-screen.loading=Loading
+loading-screen.downloading-song=Downloading soundtrack
+loading-screen.downloading-level=Downloading level
+loading-screen.generating-buildings=Generating buildings
 loading-screen.best=Best
 loading-screen.custom-song-warning=Please be patient, it may take some time when analysing your song for the first time...
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.serwylo.beatgame"
         minSdkVersion 14
         targetSdkVersion 30
-        versionCode 21
-        versionName "0.13.2"
+        versionCode 22
+        versionName "0.14.0"
     }
     buildTypes {
         release {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,11 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -21,6 +21,8 @@
 
 -verbose
 
+-dontobfuscate
+
 -dontwarn android.support.**
 -dontwarn com.badlogic.gdx.backends.android.AndroidFragmentApplication
 -dontwarn com.badlogic.gdx.utils.GdxBuild
@@ -29,6 +31,11 @@
 -dontwarn com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild
 
 -keep class com.badlogic.gdx.controllers.android.AndroidControllers
+
+# Dynamicall load many of these classes from a skin.json file.
+-keep class com.badlogic.gdx.scenes.scene2d.** {
+  *;
+}
 
 -keepclassmembers class com.badlogic.gdx.backends.android.AndroidInput* {
    <init>(com.badlogic.gdx.Application, android.content.Context, java.lang.Object, com.badlogic.gdx.backends.android.AndroidApplicationConfiguration);

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -37,6 +37,12 @@
   *;
 }
 
+-keep class com.serwylo.beatgame.** {
+  *;
+}
+
+-keepattributes *Annotation*
+
 -keepclassmembers class com.badlogic.gdx.backends.android.AndroidInput* {
    <init>(com.badlogic.gdx.Application, android.content.Context, java.lang.Object, com.badlogic.gdx.backends.android.AndroidApplicationConfiguration);
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ allprojects {
         box2DLightsVersion = '1.5'
         ashleyVersion = '1.7.3'
         aiVersion = '1.8.2'
+        ktorVersion = '1.6.0'
     }
 
     repositories {
@@ -114,6 +115,11 @@ project(":core") {
         implementation 'com.gmail.blueboxware:libgdxpluginannotations:1.16'
         implementation 'com.crashinvaders.vfx:gdx-vfx-core:0.5.0'
         implementation 'com.crashinvaders.vfx:gdx-vfx-effects:0.5.0'
+        implementation 'com.google.code.gson:gson:2.8.6'
+        implementation "io.ktor:ktor-client-core:$ktorVersion"
+        implementation "io.ktor:ktor-client-cio:$ktorVersion"
+        implementation "io.ktor:ktor-client-gson:$ktorVersion"
+        implementation "io.ktor:ktor-gson:$ktorVersion"
 
         testImplementation 'junit:junit:4.13.2'
         testImplementation "org.mockito:mockito-all:1.9.0"

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ allprojects {
         ashleyVersion = '1.7.3'
         aiVersion = '1.8.2'
         ktorVersion = '1.6.0'
+        coroutinesVersion = '1.6.4'
+        ktxVersion = '1.10.0-rc1'
     }
 
     repositories {
@@ -112,10 +114,15 @@ project(":core") {
         api "com.badlogicgames.gdx:gdx:$gdxVersion"
         api "com.badlogicgames.gdx:gdx-freetype:$gdxVersion"
         api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+        api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+
+        api "io.github.libktx:ktx-async:$ktxVersion"
+
         implementation 'com.gmail.blueboxware:libgdxpluginannotations:1.16'
         implementation 'com.crashinvaders.vfx:gdx-vfx-core:0.5.0'
         implementation 'com.crashinvaders.vfx:gdx-vfx-effects:0.5.0'
         implementation 'com.google.code.gson:gson:2.8.6'
+
         implementation "io.ktor:ktor-client-core:$ktorVersion"
         implementation "io.ktor:ktor-client-cio:$ktorVersion"
         implementation "io.ktor:ktor-client-gson:$ktorVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ project(":core") {
         api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
         api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
+        api "io.github.libktx:ktx-actors:$ktxVersion"
         api "io.github.libktx:ktx-async:$ktxVersion"
 
         implementation 'com.gmail.blueboxware:libgdxpluginannotations:1.16'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,4 @@
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/core/src/com/serwylo/beatgame/BeatFeetGame.kt
+++ b/core/src/com/serwylo/beatgame/BeatFeetGame.kt
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Game
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
+import com.google.gson.Gson
 import com.serwylo.beatgame.audio.features.LevelData
 import com.serwylo.beatgame.levels.Level
 import com.serwylo.beatgame.levels.World

--- a/core/src/com/serwylo/beatgame/BeatFeetGame.kt
+++ b/core/src/com/serwylo/beatgame/BeatFeetGame.kt
@@ -3,7 +3,6 @@ package com.serwylo.beatgame
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.Game
 import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.serwylo.beatgame.audio.features.LevelData

--- a/core/src/com/serwylo/beatgame/BeatFeetGame.kt
+++ b/core/src/com/serwylo/beatgame/BeatFeetGame.kt
@@ -8,7 +8,6 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.serwylo.beatgame.audio.features.LevelData
 import com.serwylo.beatgame.screens.*
-import java.util.*
 
 open class BeatFeetGame(val platformListener: PlatformListener, private val verbose: Boolean) : Game() {
 

--- a/core/src/com/serwylo/beatgame/BeatFeetGame.kt
+++ b/core/src/com/serwylo/beatgame/BeatFeetGame.kt
@@ -6,7 +6,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
-import com.serwylo.beatgame.audio.features.World
+import com.serwylo.beatgame.audio.features.LevelData
 import com.serwylo.beatgame.screens.*
 import java.util.*
 
@@ -38,9 +38,9 @@ open class BeatFeetGame(val platformListener: PlatformListener, private val verb
         }
     }
 
-    fun startGame(world: World) {
+    fun startGame(levelData: LevelData) {
         Gdx.app.postRunnable {
-            setScreen(PlatformGameScreen(this, world))
+            setScreen(PlatformGameScreen(this, levelData))
         }
     }
 

--- a/core/src/com/serwylo/beatgame/BeatFeetGame.kt
+++ b/core/src/com/serwylo/beatgame/BeatFeetGame.kt
@@ -10,6 +10,7 @@ import com.serwylo.beatgame.audio.features.LevelData
 import com.serwylo.beatgame.levels.Level
 import com.serwylo.beatgame.levels.World
 import com.serwylo.beatgame.screens.*
+import ktx.async.KtxAsync
 
 open class BeatFeetGame(val platformListener: PlatformListener, private val verbose: Boolean) : Game() {
 
@@ -23,6 +24,8 @@ open class BeatFeetGame(val platformListener: PlatformListener, private val verb
         if (verbose) {
             Gdx.app.logLevel = Application.LOG_DEBUG
         }
+
+        KtxAsync.initiate()
 
         assets = Assets(Assets.getLocale())
 

--- a/core/src/com/serwylo/beatgame/BeatFeetGame.kt
+++ b/core/src/com/serwylo/beatgame/BeatFeetGame.kt
@@ -7,6 +7,8 @@ import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer
 import com.serwylo.beatgame.audio.features.LevelData
+import com.serwylo.beatgame.levels.Level
+import com.serwylo.beatgame.levels.World
 import com.serwylo.beatgame.screens.*
 
 open class BeatFeetGame(val platformListener: PlatformListener, private val verbose: Boolean) : Game() {
@@ -31,15 +33,15 @@ open class BeatFeetGame(val platformListener: PlatformListener, private val verb
         setScreen(MainMenuScreen(this))
     }
 
-    fun loadGame(musicFile: FileHandle, songName: String) {
+    fun loadGame(level: Level) {
         Gdx.app.postRunnable {
-            setScreen(LoadingScreen(this, musicFile, songName))
+            setScreen(LoadingScreen(this, level))
         }
     }
 
-    fun startGame(levelData: LevelData) {
+    fun startGame(level: Level, levelData: LevelData) {
         Gdx.app.postRunnable {
-            setScreen(PlatformGameScreen(this, levelData))
+            setScreen(PlatformGameScreen(this, level, levelData))
         }
     }
 
@@ -49,9 +51,9 @@ open class BeatFeetGame(val platformListener: PlatformListener, private val verb
         }
     }
 
-    fun showLevelSelectMenu() {
+    fun showLevelSelectMenu(world: World) {
         Gdx.app.postRunnable {
-            setScreen(LevelSelectScreen(this))
+            setScreen(LevelSelectScreen(this, world))
         }
     }
 

--- a/core/src/com/serwylo/beatgame/audio/AudioIO.kt
+++ b/core/src/com/serwylo/beatgame/audio/AudioIO.kt
@@ -15,12 +15,6 @@ private const val TAG = "WorldCache"
 
 fun loadLevelDataFromMp3(musicFile: FileHandle): LevelData {
 
-    val precompiled = loadPrecompiledLevelData(musicFile)
-    if (precompiled != null) {
-        Gdx.app.debug(TAG, "Loaded precompiled world")
-        return precompiled
-    }
-
     val fromCache = loadLevelDataFromCache(musicFile)
     if (fromCache != null) {
         Gdx.app.debug(TAG, "Loaded world from cache")
@@ -107,18 +101,11 @@ private fun loadLevelDataFromCache(musicFile: FileHandle): LevelData? {
 
 }
 
-private fun loadPrecompiledLevelData(musicFile: FileHandle): LevelData? {
-
-    val file = getPrecompiledFile(musicFile)
-    if (file == null || !file.exists()) {
-        // Could be the case for custom songs, or for when we are experimenting adding new songs.
-        Gdx.app.debug(TAG, "Precompiled file for world ${musicFile.path()} doesn't exist")
-        return null
-    }
+fun loadCachedLevelData(levelDataFile: FileHandle): LevelData {
 
     try {
 
-        val json = file.readString()
+        val json = levelDataFile.readString()
         val data = Gson().fromJson(json, CachedWorldData::class.java)
 
         if (data.version != CachedWorldData.currentVersion) {
@@ -130,7 +117,7 @@ private fun loadPrecompiledLevelData(musicFile: FileHandle): LevelData? {
     } catch (e: Exception) {
         // Be pretty liberal at throwing away cached files here. That gives us the freedom to change
         // the data structure if required without having to worry about if this will work or not.
-        throw RuntimeException("Error while reading precompiled world data for ${musicFile.path()}.", e)
+        throw RuntimeException("Error while reading precompiled world data for ${levelDataFile.path()}.", e)
     }
 
 }
@@ -168,22 +155,6 @@ private fun getCacheFile(musicFile: FileHandle): FileHandle {
     }
 
     return Gdx.files.local("${CACHE_DIR}${File.separator}$name.json")
-
-}
-
-private fun getPrecompiledFile(musicFile: FileHandle): FileHandle? {
-
-    val name = musicFile.nameWithoutExtension()
-    if (name == "custom") {
-        return null
-    }
-
-    val dataFile = Gdx.files.internal("songs${File.separator}data${File.separator}${name}.json")
-    if (dataFile.exists()) {
-        return dataFile
-    }
-
-    return null
 
 }
 

--- a/core/src/com/serwylo/beatgame/audio/AudioIO.kt
+++ b/core/src/com/serwylo/beatgame/audio/AudioIO.kt
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.google.gson.Gson
 import com.serwylo.beatgame.audio.features.Feature
-import com.serwylo.beatgame.audio.features.World
+import com.serwylo.beatgame.audio.features.LevelData
 import com.serwylo.beatgame.audio.fft.FFTWindow
 import com.serwylo.beatgame.audio.fft.calculateMp3FFTWithValues
 import com.serwylo.beatgame.audio.playground.*
@@ -13,7 +13,7 @@ import kotlin.math.ln
 
 private const val TAG = "WorldCache"
 
-fun loadWorldFromMp3(musicFile: FileHandle): World {
+fun loadWorldFromMp3(musicFile: FileHandle): LevelData {
 
     val precompiled = loadPrecompiled(musicFile)
     if (precompiled != null) {
@@ -38,7 +38,7 @@ fun customMp3(): FileHandle {
     return Gdx.files.external("BeatFeet${File.separator}custom.mp3")
 }
 
-fun loadFromDisk(musicFile: FileHandle): World {
+fun loadFromDisk(musicFile: FileHandle): LevelData {
 
     Gdx.app.debug(TAG, "Generating world from ${musicFile.path()}...")
 
@@ -72,11 +72,11 @@ fun loadFromDisk(musicFile: FileHandle): World {
     val duration = spectogram.mp3Data.pcmSamples.size / spectogram.mp3Data.sampleRate
 
     Gdx.app.debug(TAG, "Finished generating world")
-    return World(musicFile, duration, heightMap, features[0], features[1], features[2])
+    return LevelData(musicFile, duration, heightMap, features[0], features[1], features[2])
 
 }
 
-private fun loadFromCache(musicFile: FileHandle): World? {
+private fun loadFromCache(musicFile: FileHandle): LevelData? {
 
     val file = getCacheFile(musicFile).file()
     if (!file.exists()) {
@@ -95,7 +95,7 @@ private fun loadFromCache(musicFile: FileHandle): World? {
             return null
         }
 
-        return World(musicFile, data.duration, arrayOf(), data.featuresLow, data.featuresMid, data.featuresHigh)
+        return LevelData(musicFile, data.duration, arrayOf(), data.featuresLow, data.featuresMid, data.featuresHigh)
 
     } catch (e: Exception) {
         // Be pretty liberal at throwing away cached files here. That gives us the freedom to change
@@ -107,7 +107,7 @@ private fun loadFromCache(musicFile: FileHandle): World? {
 
 }
 
-private fun loadPrecompiled(musicFile: FileHandle): World? {
+private fun loadPrecompiled(musicFile: FileHandle): LevelData? {
 
     val file = getPrecompiledFile(musicFile)
     if (file == null || !file.exists()) {
@@ -125,7 +125,7 @@ private fun loadPrecompiled(musicFile: FileHandle): World? {
             error("Precompiled world data is version ${data.version}, whereas we only know how to handle version ${CachedWorldData.currentVersion} with certainty. Perhaps we need to compile again using :song-extract:processSongs?")
         }
 
-        return World(musicFile, data.duration, arrayOf(), data.featuresLow, data.featuresMid, data.featuresHigh)
+        return LevelData(musicFile, data.duration, arrayOf(), data.featuresLow, data.featuresMid, data.featuresHigh)
 
     } catch (e: Exception) {
         // Be pretty liberal at throwing away cached files here. That gives us the freedom to change
@@ -135,19 +135,19 @@ private fun loadPrecompiled(musicFile: FileHandle): World? {
 
 }
 
-private fun cacheWorld(musicFile: FileHandle, world: World) {
+private fun cacheWorld(musicFile: FileHandle, levelData: LevelData) {
 
     val file = getCacheFile(musicFile)
 
     Gdx.app.debug(TAG, "Caching world for ${musicFile.path()} to ${file.file().absolutePath}")
 
-    saveWorldToDisk(file, world)
+    saveWorldToDisk(file, levelData)
 
 }
 
-fun saveWorldToDisk(file: FileHandle, world: World) {
+fun saveWorldToDisk(file: FileHandle, levelData: LevelData) {
 
-    val json = Gson().toJson(CachedWorldData(world.duration, world.featuresLow, world.featuresMid, world.featuresHigh))
+    val json = Gson().toJson(CachedWorldData(levelData.duration, levelData.featuresLow, levelData.featuresMid, levelData.featuresHigh))
     file.writeString(json, false)
 
 }

--- a/core/src/com/serwylo/beatgame/audio/features/LevelData.kt
+++ b/core/src/com/serwylo/beatgame/audio/features/LevelData.kt
@@ -5,7 +5,7 @@ import com.badlogic.gdx.math.Vector2
 import com.serwylo.beatgame.levels.Level
 import com.serwylo.beatgame.levels.Levels
 
-class World(
+class LevelData(
         val musicFile: FileHandle,
         val duration: Int,
         val heightMap: Array<Vector2>,

--- a/core/src/com/serwylo/beatgame/audio/features/LevelData.kt
+++ b/core/src/com/serwylo/beatgame/audio/features/LevelData.kt
@@ -15,7 +15,7 @@ class LevelData(
 ) {
 
     fun level(): Level {
-        return Levels.bySong(musicFile.name())
+        return Levels.byId(musicFile.name())
     }
 
 }

--- a/core/src/com/serwylo/beatgame/audio/features/LevelData.kt
+++ b/core/src/com/serwylo/beatgame/audio/features/LevelData.kt
@@ -1,21 +1,11 @@
 package com.serwylo.beatgame.audio.features
 
-import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.math.Vector2
-import com.serwylo.beatgame.levels.Level
-import com.serwylo.beatgame.levels.Levels
 
 class LevelData(
-        val musicFile: FileHandle,
         val duration: Int,
         val heightMap: Array<Vector2>,
         val featuresLow: List<Feature>,
         val featuresMid: List<Feature>,
         val featuresHigh: List<Feature>
-) {
-
-    fun level(): Level {
-        return Levels.byId(musicFile.name())
-    }
-
-}
+)

--- a/core/src/com/serwylo/beatgame/levels/HighScore.kt
+++ b/core/src/com/serwylo/beatgame/levels/HighScore.kt
@@ -16,7 +16,7 @@ fun clearAllHighScores() {
 }
 
 fun loadHighScore(level: Level): HighScore {
-    val json = prefs().getString(level.mp3Name, "")
+    val json = prefs().getString(level.getId(), "")
     return if (json == "") {
         HighScore(0f, 0, 0, 0)
     } else {
@@ -40,7 +40,7 @@ fun saveHighScore(level: Level, score: Score, force: Boolean = false): HighScore
 
     val json = Gson().toJson(toSave)
 
-    prefs().putString(level.mp3Name, json).flush()
+    prefs().putString(level.getId(), json).flush()
 
     return toSave
 }

--- a/core/src/com/serwylo/beatgame/levels/Level.kt
+++ b/core/src/com/serwylo/beatgame/levels/Level.kt
@@ -92,10 +92,10 @@ class RemoteLevel(private val world: RemoteWorld, private val data: WorldDTO.Lev
     override fun getLabel(strings: I18NBundle) = data.label
     override fun getUnlockRequirements() = Unlocked()
     override fun getWorld() = world
+    override fun getMp3File() = getCachedMp3File(this)
 
-    override fun getMp3File(): FileHandle {
-        TODO("Not yet implemented")
-    }
+    suspend fun ensureMp3Downloaded() = downloadAndCacheFile(data.mp3Url, getCachedMp3File(this))
+    suspend fun ensureLevelDataDownloaded() = downloadAndCacheFile(data.dataUrl, getCachedLevelDataFile(this))
 
 }
 

--- a/core/src/com/serwylo/beatgame/levels/Level.kt
+++ b/core/src/com/serwylo/beatgame/levels/Level.kt
@@ -15,6 +15,7 @@ interface Level {
 }
 
 interface World {
+    fun getId(): String
     fun getLabel(strings: I18NBundle): String
     fun getLevels(): List<Level>
 }
@@ -76,7 +77,33 @@ object CustomLevel: Level {
 
 }
 
+class RemoteWorld(private val summary: WorldsDTO.WorldSummaryDTO, private val data: WorldDTO): World {
+
+    private val levels = data.getLevels().map { RemoteLevel(this, it) }
+
+    override fun getId() = summary.url
+    override fun getLabel(strings: I18NBundle) = summary.name
+    override fun getLevels() = levels
+}
+
+class RemoteLevel(private val world: RemoteWorld, private val data: WorldDTO.LevelDTO): Level {
+
+    override fun getId() = data.id
+    override fun getLabel(strings: I18NBundle) = data.label
+    override fun getUnlockRequirements() = Unlocked()
+    override fun getWorld() = world
+
+    override fun getMp3File(): FileHandle {
+        TODO("Not yet implemented")
+    }
+
+}
+
 object TheOriginalWorld: World {
+
+    override fun getId(): String {
+        return "built-in:the-original-world"
+    }
 
     override fun getLabel(strings: I18NBundle): String {
         return strings["worlds.the-original"]

--- a/core/src/com/serwylo/beatgame/levels/Level.kt
+++ b/core/src/com/serwylo/beatgame/levels/Level.kt
@@ -88,8 +88,8 @@ class RemoteLevel(private val world: RemoteWorld, private val data: WorldDTO.Lev
     suspend fun ensureLevelDataDownloaded() = downloadAndCacheFile(data.dataUrl, getLevelDataFile())
 
     override fun getUnlockRequirements(): UnlockRequirements {
-        val isWorldUnlocked = data.unlockRequirements.type == "unlocked"
-        val isLevelUnlocked = world.summary.unlockRequirements.type == "unlocked"
+        val isWorldUnlocked = world.summary.unlockRequirements.type == "unlocked"
+        val isLevelUnlocked = data.unlockRequirements.type == "unlocked"
 
         val requiredForWorld = if (isWorldUnlocked) 0 else world.summary.unlockRequirements.numRequired ?: 0
         val requiredForLevel = if (isLevelUnlocked) 0 else data.unlockRequirements.numRequired ?: 0

--- a/core/src/com/serwylo/beatgame/levels/Level.kt
+++ b/core/src/com/serwylo/beatgame/levels/Level.kt
@@ -1,119 +1,161 @@
 package com.serwylo.beatgame.levels
 
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.files.FileHandle
 import com.badlogic.gdx.utils.I18NBundle
 import com.serwylo.beatgame.levels.achievements.Achievement
+import java.io.File
 
-data class Level(
-        val mp3Name: String,
-        val labelId: String,
-        val unlockRequirements: UnlockRequirements
-)
+interface Level {
+    fun getId(): String
+    fun getMp3File(): FileHandle
+    fun getLabel(strings: I18NBundle): String
+    fun getUnlockRequirements(): UnlockRequirements
+}
+
+class BuiltInLevel(
+    private val mp3Name: String,
+    private val labelId: String,
+    private val toUnlock: UnlockRequirements
+): Level {
+
+    override  fun getId(): String {
+        return mp3Name
+    }
+
+    override fun getMp3File(): FileHandle {
+        return Gdx.files.internal("songs${File.separator}mp3${File.separator}${mp3Name}")
+    }
+
+    override fun getLabel(strings: I18NBundle): String {
+        return strings[labelId]
+    }
+
+    override fun getUnlockRequirements(): UnlockRequirements {
+        return toUnlock
+    }
+
+}
+
+/* TODO: Dynamically fetch levels from the web.
+class RemoteLevel(): Level {
+    override fun getMp3File(): FileHandle {
+    }
+
+    override fun getLabel(strings: I18NBundle): String {
+    }
+
+    override fun getUnlockRequirements(): UnlockRequirements {
+    }
+
+}
+*/
 
 object Levels {
 
-    val TheLaundryRoom = Level(
+    val TheLaundryRoom = BuiltInLevel(
             "the_haunted_mansion_the_laundry_room.mp3",
             "levels.the-laundry-room",
             Unlocked()
     )
 
-    val TheCourtyard = Level(
+    val TheCourtyard = BuiltInLevel(
             "the_haunted_mansion_the_courtyard.mp3",
             "levels.the-courtyard",
             Unlocked()
     )
 
-    val Maintenance = Level(
+    val Maintenance = BuiltInLevel(
             "health_and_safety_maintenance.mp3",
             "levels.maintenance",
             TotalAchievements(5)
     )
 
-    val ForcingTheGamecard = Level(
+    val ForcingTheGamecard = BuiltInLevel(
             "health_and_safety_forcing_the_gamecard.mp3",
             "levels.forcing-the-gamecard",
             TotalAchievements(10)
     )
 
-    val SharplyBentWire = Level(
+    val SharplyBentWire = BuiltInLevel(
             "health_and_safety_sharply_bent_wire.mp3",
             "levels.sharply-bent-wire",
             TotalAchievements(15)
     )
 
-    val EyeTwitching = Level(
+    val EyeTwitching = BuiltInLevel(
             "health_and_safety_eye_twitching.mp3",
             "levels.eye-twitching",
             TotalAchievements(20)
     )
 
-    val LightFlashes = Level(
+    val LightFlashes = BuiltInLevel(
             "health_and_safety_light_flashes.mp3",
             "levels.light-flashes",
             TotalAchievements(25)
     )
 
-    val PlayInAWellLitRoom = Level(
+    val PlayInAWellLitRoom = BuiltInLevel(
             "health_and_safety_play_in_a_well_lit_room.mp3",
             "levels.play-in-a-well-lit-room",
             TotalAchievements(30)
     )
 
-    val ContactWithMoistureAndDirt = Level(
+    val ContactWithMoistureAndDirt = BuiltInLevel(
             "health_and_safety_contact_with_moisture_and_dirt.mp3",
             "levels.contact-with-moisture-and-dirt",
             TotalAchievements(35)
     )
 
-    val TheBallroom = Level(
+    val TheBallroom = BuiltInLevel(
             "the_haunted_mansion_the_ballroom.mp3",
             "levels.the-ballroom",
             TotalAchievements(40)
     )
 
-    val OldClock = Level(
+    val OldClock = BuiltInLevel(
             "awakenings_old_clock.mp3",
             "levels.old-clock",
             TotalAchievements(45)
     )
 
-    val RegulationsForEquipment = Level(
+    val RegulationsForEquipment = BuiltInLevel(
             "health_and_safety_regulations_for_equipment_use.mp3",
             "levels.regulations-for-equipment",
             TotalAchievements(50)
     )
 
-    val Convulsions = Level(
+    val Convulsions = BuiltInLevel(
             "health_and_safety_convulsions.mp3",
             "levels.convulsions",
             TotalAchievements(55)
     )
 
-    val ContactWithDustAndLint = Level(
+    val ContactWithDustAndLint = BuiltInLevel(
             "health_and_safety_contact_with_dust_and_lint.mp3",
             "levels.contact-with-dust-and-lint",
             TotalAchievements(60)
     )
 
-    val TheExerciseRoom = Level(
+    val TheExerciseRoom = BuiltInLevel(
             "the_haunted_mansion_the_exercise_room.mp3",
             "levels.the-exercise-room",
             TotalAchievements(65)
     )
 
-    val Vivaldi = Level(
+    val Vivaldi = BuiltInLevel(
             "vivaldi.mp3",
             "levels.vivaldi",
             TotalAchievements(75)
     )
 
-    val ReorientTheReceivingAntenna = Level(
+    val ReorientTheReceivingAntenna = BuiltInLevel(
             "health_and_safety_reorient_the_receiving_antenna.mp3",
             "levels.reorient-the-receiving-antenna",
             TotalAchievements(80)
     )
 
-    val Custom  = Level(
+    val Custom  = BuiltInLevel(
             "custom.mp3",
             "levels.custom",
             Unlocked()
@@ -140,9 +182,9 @@ object Levels {
             Custom
     )
 
-    fun bySong(mp3Name: String): Level {
-        return all.find { it.mp3Name == mp3Name }
-                ?: error("Could not find level corresponding to mp3 $mp3Name")
+    fun byId(id: String): Level {
+        return all.find { it.getId() == id }
+                ?: error("Could not find level with ID: \"$id\"")
     }
 
 }

--- a/core/src/com/serwylo/beatgame/levels/Level.kt
+++ b/core/src/com/serwylo/beatgame/levels/Level.kt
@@ -11,14 +11,24 @@ interface Level {
     fun getMp3File(): FileHandle
     fun getLabel(strings: I18NBundle): String
     fun getUnlockRequirements(): UnlockRequirements
+    fun getWorld(): World
+}
+
+interface World {
+    fun getLabel(strings: I18NBundle): String
+    fun getLevels(): List<Level>
+}
+
+fun findLevelById(id: String): Level? {
+    return TheOriginalWorld.getLevels().find { it.getId() == id }
 }
 
 class BuiltInLevel(
+    private val world: World,
     private val mp3Name: String,
     private val labelId: String,
-    private val toUnlock: UnlockRequirements
+    private val toUnlock: UnlockRequirements,
 ): Level {
-
     override  fun getId(): String {
         return mp3Name
     }
@@ -35,133 +45,45 @@ class BuiltInLevel(
         return toUnlock
     }
 
+    override fun getWorld(): World {
+        return world
+    }
 }
 
-/* TODO: Dynamically fetch levels from the web.
-class RemoteLevel(): Level {
+object CustomLevel: Level {
+
+    private val mp3File = Gdx.files.external("BeatFeet${File.separator}custom.mp3")
+
+    override fun getId(): String {
+        return "custom.mp3"
+    }
+
     override fun getMp3File(): FileHandle {
+        return mp3File
     }
 
     override fun getLabel(strings: I18NBundle): String {
+        return strings["levels.custom"]
     }
 
     override fun getUnlockRequirements(): UnlockRequirements {
+        return Unlocked()
+    }
+
+    override fun getWorld(): World {
+        return TheOriginalWorld
     }
 
 }
-*/
 
-object Levels {
+object TheOriginalWorld: World {
 
-    val TheLaundryRoom = BuiltInLevel(
-            "the_haunted_mansion_the_laundry_room.mp3",
-            "levels.the-laundry-room",
-            Unlocked()
-    )
+    override fun getLabel(strings: I18NBundle): String {
+        return strings["worlds.the-original"]
+    }
 
-    val TheCourtyard = BuiltInLevel(
-            "the_haunted_mansion_the_courtyard.mp3",
-            "levels.the-courtyard",
-            Unlocked()
-    )
-
-    val Maintenance = BuiltInLevel(
-            "health_and_safety_maintenance.mp3",
-            "levels.maintenance",
-            TotalAchievements(5)
-    )
-
-    val ForcingTheGamecard = BuiltInLevel(
-            "health_and_safety_forcing_the_gamecard.mp3",
-            "levels.forcing-the-gamecard",
-            TotalAchievements(10)
-    )
-
-    val SharplyBentWire = BuiltInLevel(
-            "health_and_safety_sharply_bent_wire.mp3",
-            "levels.sharply-bent-wire",
-            TotalAchievements(15)
-    )
-
-    val EyeTwitching = BuiltInLevel(
-            "health_and_safety_eye_twitching.mp3",
-            "levels.eye-twitching",
-            TotalAchievements(20)
-    )
-
-    val LightFlashes = BuiltInLevel(
-            "health_and_safety_light_flashes.mp3",
-            "levels.light-flashes",
-            TotalAchievements(25)
-    )
-
-    val PlayInAWellLitRoom = BuiltInLevel(
-            "health_and_safety_play_in_a_well_lit_room.mp3",
-            "levels.play-in-a-well-lit-room",
-            TotalAchievements(30)
-    )
-
-    val ContactWithMoistureAndDirt = BuiltInLevel(
-            "health_and_safety_contact_with_moisture_and_dirt.mp3",
-            "levels.contact-with-moisture-and-dirt",
-            TotalAchievements(35)
-    )
-
-    val TheBallroom = BuiltInLevel(
-            "the_haunted_mansion_the_ballroom.mp3",
-            "levels.the-ballroom",
-            TotalAchievements(40)
-    )
-
-    val OldClock = BuiltInLevel(
-            "awakenings_old_clock.mp3",
-            "levels.old-clock",
-            TotalAchievements(45)
-    )
-
-    val RegulationsForEquipment = BuiltInLevel(
-            "health_and_safety_regulations_for_equipment_use.mp3",
-            "levels.regulations-for-equipment",
-            TotalAchievements(50)
-    )
-
-    val Convulsions = BuiltInLevel(
-            "health_and_safety_convulsions.mp3",
-            "levels.convulsions",
-            TotalAchievements(55)
-    )
-
-    val ContactWithDustAndLint = BuiltInLevel(
-            "health_and_safety_contact_with_dust_and_lint.mp3",
-            "levels.contact-with-dust-and-lint",
-            TotalAchievements(60)
-    )
-
-    val TheExerciseRoom = BuiltInLevel(
-            "the_haunted_mansion_the_exercise_room.mp3",
-            "levels.the-exercise-room",
-            TotalAchievements(65)
-    )
-
-    val Vivaldi = BuiltInLevel(
-            "vivaldi.mp3",
-            "levels.vivaldi",
-            TotalAchievements(75)
-    )
-
-    val ReorientTheReceivingAntenna = BuiltInLevel(
-            "health_and_safety_reorient_the_receiving_antenna.mp3",
-            "levels.reorient-the-receiving-antenna",
-            TotalAchievements(80)
-    )
-
-    val Custom  = BuiltInLevel(
-            "custom.mp3",
-            "levels.custom",
-            Unlocked()
-    )
-
-    val all = listOf(
+    override fun getLevels(): List<Level> {
+        return listOf(
             TheLaundryRoom,
             TheCourtyard,
             Maintenance,
@@ -179,15 +101,150 @@ object Levels {
             TheExerciseRoom,
             Vivaldi,
             ReorientTheReceivingAntenna,
-            Custom
-    )
-
-    fun byId(id: String): Level {
-        return all.find { it.getId() == id }
-                ?: error("Could not find level with ID: \"$id\"")
+            CustomLevel,
+        )
     }
 
+    val TheLaundryRoom = BuiltInLevel(
+        this,
+        "the_haunted_mansion_the_laundry_room.mp3",
+        "levels.the-laundry-room",
+        Unlocked()
+    )
+
+    val TheCourtyard = BuiltInLevel(
+        this,
+        "the_haunted_mansion_the_courtyard.mp3",
+        "levels.the-courtyard",
+        Unlocked()
+    )
+
+    val Maintenance = BuiltInLevel(
+        this,
+        "health_and_safety_maintenance.mp3",
+        "levels.maintenance",
+        TotalAchievements(5)
+    )
+
+    val ForcingTheGamecard = BuiltInLevel(
+        this,
+        "health_and_safety_forcing_the_gamecard.mp3",
+        "levels.forcing-the-gamecard",
+        TotalAchievements(10)
+    )
+
+    val SharplyBentWire = BuiltInLevel(
+        this,
+        "health_and_safety_sharply_bent_wire.mp3",
+        "levels.sharply-bent-wire",
+        TotalAchievements(15)
+    )
+
+    val EyeTwitching = BuiltInLevel(
+        this,
+        "health_and_safety_eye_twitching.mp3",
+        "levels.eye-twitching",
+        TotalAchievements(20)
+    )
+
+    val LightFlashes = BuiltInLevel(
+        this,
+        "health_and_safety_light_flashes.mp3",
+        "levels.light-flashes",
+        TotalAchievements(25)
+    )
+
+    val PlayInAWellLitRoom = BuiltInLevel(
+        this,
+        "health_and_safety_play_in_a_well_lit_room.mp3",
+        "levels.play-in-a-well-lit-room",
+        TotalAchievements(30)
+    )
+
+    val ContactWithMoistureAndDirt = BuiltInLevel(
+        this,
+        "health_and_safety_contact_with_moisture_and_dirt.mp3",
+        "levels.contact-with-moisture-and-dirt",
+        TotalAchievements(35)
+    )
+
+    val TheBallroom = BuiltInLevel(
+        this,
+        "the_haunted_mansion_the_ballroom.mp3",
+        "levels.the-ballroom",
+        TotalAchievements(40)
+    )
+
+    val OldClock = BuiltInLevel(
+        this,
+        "awakenings_old_clock.mp3",
+        "levels.old-clock",
+        TotalAchievements(45)
+    )
+
+    val RegulationsForEquipment = BuiltInLevel(
+        this,
+        "health_and_safety_regulations_for_equipment_use.mp3",
+        "levels.regulations-for-equipment",
+        TotalAchievements(50)
+    )
+
+    val Convulsions = BuiltInLevel(
+        this,
+        "health_and_safety_convulsions.mp3",
+        "levels.convulsions",
+        TotalAchievements(55)
+    )
+
+    val ContactWithDustAndLint = BuiltInLevel(
+        this,
+        "health_and_safety_contact_with_dust_and_lint.mp3",
+        "levels.contact-with-dust-and-lint",
+        TotalAchievements(60)
+    )
+
+    val TheExerciseRoom = BuiltInLevel(
+        this,
+        "the_haunted_mansion_the_exercise_room.mp3",
+        "levels.the-exercise-room",
+        TotalAchievements(65)
+    )
+
+    val Vivaldi = BuiltInLevel(
+        this,
+        "vivaldi.mp3",
+        "levels.vivaldi",
+        TotalAchievements(75)
+    )
+
+    val ReorientTheReceivingAntenna = BuiltInLevel(
+        this,
+        "health_and_safety_reorient_the_receiving_antenna.mp3",
+        "levels.reorient-the-receiving-antenna",
+        TotalAchievements(80)
+    )
+
 }
+
+/*class RemoteLevel(): Level {
+
+    override fun getId(): String {
+
+    }
+
+    override fun getMp3File(): FileHandle {
+
+    }
+
+    override fun getLabel(strings: I18NBundle): String {
+
+    }
+
+    override fun getUnlockRequirements(): UnlockRequirements {
+
+    }
+
+}*/
 
 abstract class UnlockRequirements {
     abstract fun isLocked(achievements: List<Achievement>): Boolean

--- a/core/src/com/serwylo/beatgame/levels/achievements/Achievement.kt
+++ b/core/src/com/serwylo/beatgame/levels/achievements/Achievement.kt
@@ -1,8 +1,6 @@
 package com.serwylo.beatgame.levels.achievements
 
-import com.serwylo.beatgame.levels.Level
-
 data class Achievement(
-        val type: AchievementType,
-        val level: Level
+    val type: AchievementType,
+    val levelId: String,
 )

--- a/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
+++ b/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
@@ -3,7 +3,7 @@ package com.serwylo.beatgame.levels.achievements
 import com.badlogic.gdx.Gdx
 import com.google.gson.Gson
 import com.serwylo.beatgame.levels.Level
-import com.serwylo.beatgame.levels.Levels
+import com.serwylo.beatgame.levels.findLevelById
 
 fun saveAchievements(level: Level, achievements: List<AchievementType>) {
 
@@ -31,13 +31,13 @@ fun loadAchievementsForLevel(level: Level): List<AchievementType> {
 }
 
 fun loadAllAchievements(): List<Achievement> {
-    return loadPersistedAchievements().achievements.map { persisted ->
+    return loadPersistedAchievements().achievements.mapNotNull { persisted ->
         val level: Level? = try {
-            Levels.byId(persisted.levelId)
+            findLevelById(persisted.levelId)
         } catch(exception: Exception) {
             // For development purposes, sometimes we find ourselves installing newer versions
             // with different levels, then going back to old versions. It is helpful without having
-            // to fully uninstall to delete all achievements, so we jsut ignore it.
+            // to fully uninstall to delete all achievements, so we just ignore it.
             Gdx.app.error("AchievementsIO", "Error loading level ${persisted.levelId}, but will just exclude this achievement.", exception)
             null
         }
@@ -50,7 +50,7 @@ fun loadAllAchievements(): List<Achievement> {
                 level,
             )
         }
-    }.filterNotNull()
+    }
 }
 
 private fun loadPersistedAchievements(): PersistedAchievements {

--- a/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
+++ b/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
@@ -3,7 +3,6 @@ package com.serwylo.beatgame.levels.achievements
 import com.badlogic.gdx.Gdx
 import com.google.gson.Gson
 import com.serwylo.beatgame.levels.Level
-import com.serwylo.beatgame.levels.findLevelById
 
 fun saveAchievements(level: Level, achievements: List<AchievementType>) {
 
@@ -31,25 +30,11 @@ fun loadAchievementsForLevel(level: Level): List<AchievementType> {
 }
 
 fun loadAllAchievements(): List<Achievement> {
-    return loadPersistedAchievements().achievements.mapNotNull { persisted ->
-        val level: Level? = try {
-            findLevelById(persisted.levelId)
-        } catch(exception: Exception) {
-            // For development purposes, sometimes we find ourselves installing newer versions
-            // with different levels, then going back to old versions. It is helpful without having
-            // to fully uninstall to delete all achievements, so we just ignore it.
-            Gdx.app.error("AchievementsIO", "Error loading level ${persisted.levelId}, but will just exclude this achievement.", exception)
-            null
-        }
-
-        if (level == null) {
-            null
-        } else {
-            Achievement(
-                allAchievements.find { it.id == persisted.achievementId }!!,
-                level,
-            )
-        }
+    return loadPersistedAchievements().achievements.map { persisted ->
+        Achievement(
+            allAchievements.find { it.id == persisted.achievementId }!!,
+            persisted.levelId,
+        )
     }
 }
 

--- a/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
+++ b/core/src/com/serwylo/beatgame/levels/achievements/AchievementsIO.kt
@@ -33,7 +33,7 @@ fun loadAchievementsForLevel(level: Level): List<AchievementType> {
 fun loadAllAchievements(): List<Achievement> {
     return loadPersistedAchievements().achievements.map { persisted ->
         val level: Level? = try {
-            Levels.bySong(persisted.levelId)
+            Levels.byId(persisted.levelId)
         } catch(exception: Exception) {
             // For development purposes, sometimes we find ourselves installing newer versions
             // with different levels, then going back to old versions. It is helpful without having
@@ -81,13 +81,13 @@ private data class PersistedAchievements(
 
         val toAdd = newAchievements
                 .filterNot { newAchievement -> existing.any { existingAchievement -> existingAchievement.achievementId == newAchievement.id } }
-                .map { PersistedAchievement(it.id, level.mp3Name) }
+                .map { PersistedAchievement(it.id, level.getId()) }
 
         return PersistedAchievements(achievements.plus(toAdd))
     }
 
     fun forLevel(level: Level): List<PersistedAchievement> {
-        return achievements.filter { it.levelId == level.mp3Name }
+        return achievements.filter { it.levelId == level.getId() }
     }
 
     val version = currentVersion

--- a/core/src/com/serwylo/beatgame/levels/levelsNet.kt
+++ b/core/src/com/serwylo/beatgame/levels/levelsNet.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.io.File
 
-// http://localhost:8888/worlds.json
-
 private const val TAG = "levelsNet"
+
+private const val WORLDS_JSON_URL = "https://beat-feet.github.io/beat-feet-levels/worlds.json"
 
 private val ID_REGEX = Regex("[\\w.-]+")
 
@@ -39,9 +39,8 @@ suspend fun loadAllWorlds(): List<World> {
 }
 
 private suspend fun fetchWorldsList(): WorldsDTO {
-    val url = "http://localhost:8888/worlds.json"
-    Gdx.app.log(TAG, "Fetching list of worlds from $url")
-    val string = downloadAndCacheString(url, Gdx.files.local(".cache/worlds/worlds.json"))
+    Gdx.app.log(TAG, "Fetching list of worlds from $WORLDS_JSON_URL")
+    val string = downloadAndCacheString(WORLDS_JSON_URL, Gdx.files.local(".cache/worlds/worlds.json"))
     return gson.fromJson(string, WorldsDTO::class.java)
 }
 

--- a/core/src/com/serwylo/beatgame/levels/levelsNet.kt
+++ b/core/src/com/serwylo/beatgame/levels/levelsNet.kt
@@ -101,9 +101,15 @@ private suspend fun fetchLevelData(url: String, output: File) {
 }
 
 data class WorldDTO(
+
     @SerializedName("levels")
     @Since(1.0)
     private val levels: List<LevelDTO>,
+
+    @SerializedName("attribution")
+    @Since(1.0)
+    val attribution: AttributionDTO?,
+
 ) {
 
     fun getLevels() = levels.filter { world ->
@@ -137,6 +143,10 @@ data class WorldDTO(
         @Since(1.0)
         val unlockRequirements: UnlockRequirementsDTO,
 
+        @SerializedName("attribution")
+        @Since(1.0)
+        val attribution: AttributionDTO?,
+
     )
 }
 
@@ -149,6 +159,22 @@ data class UnlockRequirementsDTO(
     @SerializedName("numRequired")
     @Since(1.0)
     val numRequired: Int? = null
+
+)
+
+data class AttributionDTO(
+
+    @SerializedName("license")
+    @Since(1.0)
+    val licenseName: String,
+
+    @SerializedName("sourceUrl")
+    @Since(1.0)
+    val sourceUrl: String,
+
+    @SerializedName("author")
+    @Since(1.0)
+    val author: String?,
 
 )
 
@@ -186,5 +212,6 @@ data class WorldsDTO(
         @SerializedName("unlockRequirements")
         @Since(1.0)
         val unlockRequirements: UnlockRequirementsDTO,
+
     )
 }

--- a/core/src/com/serwylo/beatgame/levels/levelsNet.kt
+++ b/core/src/com/serwylo/beatgame/levels/levelsNet.kt
@@ -11,7 +11,6 @@ import io.ktor.client.statement.*
 import io.ktor.util.cio.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.io.File
 
@@ -97,7 +96,7 @@ private suspend fun fetchLevelData(url: String, output: File) {
 }
 
 data class WorldDTO(
-    private val levels: List<LevelDTO>
+    private val levels: List<LevelDTO>,
 ) {
 
     fun getLevels() = levels.filter { world ->
@@ -114,7 +113,20 @@ data class WorldDTO(
         val label: String,
         val mp3Url: String,
         val dataUrl: String,
-    )
+        val unlockRequirements: LevelUnlockRequirementsDTO,
+    ) {
+
+        /**
+         * Although this is the same structure as [WorldUnlockRequirementsDTO], there was a quirk
+         * with [Gson.fromJson] on Android whereby this property would deserialize to null.
+         * Duplicating the class in each heirarchy seems to have resolved it.
+         */
+        data class LevelUnlockRequirementsDTO(
+            val type: String,
+            val numRequired: Int? = null,
+        )
+
+    }
 }
 
 data class WorldsDTO(
@@ -134,5 +146,16 @@ data class WorldsDTO(
         val id: String,
         val name: String,
         val url: String,
-    )
+        val unlockRequirements: WorldUnlockRequirementsDTO,
+    ) {
+
+        /**
+         * See [WorldDTO.LevelDTO.LevelUnlockRequirementsDTO].
+         */
+        data class WorldUnlockRequirementsDTO(
+            val type: String,
+            val numRequired: Int? = null,
+        )
+
+    }
 }

--- a/core/src/com/serwylo/beatgame/levels/levelsNet.kt
+++ b/core/src/com/serwylo/beatgame/levels/levelsNet.kt
@@ -3,6 +3,8 @@ package com.serwylo.beatgame.levels
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.files.FileHandle
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.google.gson.annotations.Since
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.features.json.*
@@ -17,6 +19,8 @@ import java.io.File
 private const val TAG = "levelsNet"
 
 private const val WORLDS_JSON_URL = "https://beat-feet.github.io/beat-feet-levels/worlds.json"
+
+private const val JSON_VERSION = 1
 
 private val ID_REGEX = Regex("[\\w.-]+")
 
@@ -96,6 +100,8 @@ private suspend fun fetchLevelData(url: String, output: File) {
 }
 
 data class WorldDTO(
+    @SerializedName("levels")
+    @Since(1.0)
     private val levels: List<LevelDTO>,
 ) {
 
@@ -109,28 +115,48 @@ data class WorldDTO(
     }
 
     data class LevelDTO(
+
+        @SerializedName("id")
+        @Since(1.0)
         val id: String,
+
+        @SerializedName("label")
+        @Since(1.0)
         val label: String,
+
+        @SerializedName("mp3Url")
+        @Since(1.0)
         val mp3Url: String,
+
+        @SerializedName("dataUrl")
+        @Since(1.0)
         val dataUrl: String,
-        val unlockRequirements: LevelUnlockRequirementsDTO,
-    ) {
 
-        /**
-         * Although this is the same structure as [WorldUnlockRequirementsDTO], there was a quirk
-         * with [Gson.fromJson] on Android whereby this property would deserialize to null.
-         * Duplicating the class in each heirarchy seems to have resolved it.
-         */
-        data class LevelUnlockRequirementsDTO(
-            val type: String,
-            val numRequired: Int? = null,
-        )
+        @SerializedName("unlockRequirements")
+        @Since(1.0)
+        val unlockRequirements: UnlockRequirementsDTO,
 
-    }
+    )
 }
 
+data class UnlockRequirementsDTO(
+
+    @SerializedName("type")
+    @Since(1.0)
+    val type: String,
+
+    @SerializedName("numRequired")
+    @Since(1.0)
+    val numRequired: Int? = null
+
+)
+
 data class WorldsDTO(
+
+    @SerializedName("worlds")
+    @Since(1.0)
     private val worlds: List<WorldSummaryDTO>
+
 ) {
 
     fun getWorlds() = worlds.filter { world ->
@@ -143,19 +169,21 @@ data class WorldsDTO(
     }
 
     data class WorldSummaryDTO(
+
+        @SerializedName("id")
+        @Since(1.0)
         val id: String,
+
+        @SerializedName("name")
+        @Since(1.0)
         val name: String,
+
+        @SerializedName("url")
+        @Since(1.0)
         val url: String,
-        val unlockRequirements: WorldUnlockRequirementsDTO,
-    ) {
 
-        /**
-         * See [WorldDTO.LevelDTO.LevelUnlockRequirementsDTO].
-         */
-        data class WorldUnlockRequirementsDTO(
-            val type: String,
-            val numRequired: Int? = null,
-        )
-
-    }
+        @SerializedName("unlockRequirements")
+        @Since(1.0)
+        val unlockRequirements: UnlockRequirementsDTO,
+    )
 }

--- a/core/src/com/serwylo/beatgame/levels/levelsNet.kt
+++ b/core/src/com/serwylo/beatgame/levels/levelsNet.kt
@@ -1,0 +1,132 @@
+package com.serwylo.beatgame.levels
+
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.files.FileHandle
+import com.google.gson.Gson
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.features.json.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.util.cio.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+// http://localhost:8888/worlds.json
+
+private const val TAG = "levelsNet"
+
+private val ID_REGEX = Regex("[\\w.-]+")
+
+private val httpClient = HttpClient(CIO) {
+    install(JsonFeature) {
+        serializer = GsonSerializer()
+    }
+}
+
+private val gson = Gson()
+
+suspend fun loadAllWorlds(): List<World> {
+    val remoteWorlds = fetchWorldsList().getWorlds().map { worldSummaryDto ->
+        val worldDto = fetchWorld(worldSummaryDto)
+        RemoteWorld(worldSummaryDto, worldDto)
+    }
+
+    return listOf(TheOriginalWorld) + remoteWorlds
+}
+
+private suspend fun fetchWorldsList(): WorldsDTO {
+    val url = "http://localhost:8888/worlds.json"
+    Gdx.app.log(TAG, "Fetching list of worlds from $url")
+    val string = fetchCachedString(url, Gdx.files.local(".cache/worlds/worlds.json"))
+    val worlds = gson.fromJson(string, WorldsDTO::class.java)
+    return worlds
+}
+
+private suspend fun fetchWorld(summary: WorldsDTO.WorldSummaryDTO): WorldDTO {
+    Gdx.app.log(TAG, "Fetching list of levels for world \"${summary.id}\" at ${summary.url}")
+    val string = fetchCachedString(summary.url, Gdx.files.local(".cache/worlds/${summary.id}/world.json"))
+    val world = gson.fromJson(string, WorldDTO::class.java)
+    return world
+}
+
+private suspend fun fetchCachedString(url: String, cachedFile: FileHandle): String = withContext(Dispatchers.IO) {
+    if (cachedFile.exists()) {
+        Gdx.app.log(TAG, "Reading cached string from $url (from cache file ${cachedFile.file().absolutePath})")
+        return@withContext cachedFile.readString()
+    }
+
+    cachedFile.parent().mkdirs()
+
+    Gdx.app.log(TAG, "Downloading string from $url (and caching to ${cachedFile.file().absolutePath})")
+    val string: String = httpClient.get(url)
+    cachedFile.writeString(string, false)
+
+    return@withContext string
+}
+
+private suspend fun fetchCachedFile(url: String, cachedFile: FileHandle): FileHandle = withContext(Dispatchers.IO) {
+    if (cachedFile.exists()) {
+        Gdx.app.debug(TAG, "Reading cached data file from $url (from cache file ${cachedFile.file().absolutePath})")
+        return@withContext cachedFile
+    }
+
+    cachedFile.parent().mkdirs()
+
+    Gdx.app.log(TAG, "Downloading data file from $url (and caching to ${cachedFile.file().absolutePath})")
+    val response: HttpResponse = httpClient.request(url)
+    response.content.copyAndClose(cachedFile.file().writeChannel(Dispatchers.IO))
+
+    return@withContext cachedFile
+}
+
+private suspend fun fetchLevelMp3(url: String, output: File) {
+    Gdx.app.log(TAG, "Fetching level mp3 $url and saving to $output")
+}
+
+private suspend fun fetchLevelData(url: String, output: File) {
+    Gdx.app.log(TAG, "Fetching level data $url and saving to $output")
+}
+
+data class WorldDTO(
+    private val levels: List<LevelDTO>
+) {
+
+    fun getLevels() = levels.filter { world ->
+        if (world.id.matches(ID_REGEX)) {
+            true
+        } else {
+            Gdx.app.log(TAG, "Ignoring level with id: \"${world.id}\" because it does not match the regex: \"${ID_REGEX.pattern}\". This id is used to create files on disk, so we are conservative in what we accept here for security reasons.")
+            false
+        }
+    }
+
+    data class LevelDTO(
+        val id: String,
+        val label: String,
+        val mp3Url: String,
+        val dataUrl: String,
+    )
+}
+
+data class WorldsDTO(
+    private val worlds: List<WorldSummaryDTO>
+) {
+
+    fun getWorlds() = worlds.filter { world ->
+        if (world.id.matches(ID_REGEX)) {
+            true
+        } else {
+            Gdx.app.log(TAG, "Ignoring world with id: \"${world.id}\" because it does not match the regex: \"${ID_REGEX.pattern}\". This id is used to create files on disk, so we are conservative in what we accept here for security reasons.")
+            false
+        }
+    }
+
+    data class WorldSummaryDTO(
+        val id: String,
+        val name: String,
+        val url: String,
+    )
+}

--- a/core/src/com/serwylo/beatgame/screens/AboutScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/AboutScreen.kt
@@ -2,58 +2,106 @@ package com.serwylo.beatgame.screens
 
 import com.badlogic.gdx.*
 import com.badlogic.gdx.graphics.GL20
-import com.badlogic.gdx.scenes.scene2d.ui.Label
-import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Touchable
+import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.badlogic.gdx.scenes.scene2d.ui.*
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Align
 import com.badlogic.gdx.utils.I18NBundle
 import com.serwylo.beatgame.BeatFeetGame
+import com.serwylo.beatgame.levels.World
+import com.serwylo.beatgame.levels.loadAllWorlds
 import com.serwylo.beatgame.ui.UI_SPACE
+import com.serwylo.beatgame.ui.makeErrorReport
 import com.serwylo.beatgame.ui.makeHeading
 import com.serwylo.beatgame.ui.makeStage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import ktx.actors.onClick
+import ktx.async.newSingleThreadAsyncContext
+import ktx.async.onRenderingThread
 
 class AboutScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
     private val stage = makeStage()
+    private val wrapper: Cell<Actor>
+
+    private val job = Job()
+    private val scope = CoroutineScope(newSingleThreadAsyncContext("LoadingScreen") + job)
 
     init {
         val sprites = game.assets.getSprites()
         val styles = game.assets.getStyles()
         val strings = game.assets.getStrings()
 
-        val container = VerticalGroup()
-        container.setFillParent(true)
-        container.align(Align.center)
-        container.space(UI_SPACE)
-
-        container.addActor(
-            makeHeading(strings["about.title"], sprites.logo, styles, strings) {
-                game.showMenu()
+        stage.addActor(
+            ScrollPane(
+                Table().apply {
+                    add(
+                        makeHeading(strings["about.title"], sprites.logo, styles, strings) {
+                            game.showMenu()
+                        }
+                    )
+                    row()
+                    wrapper = add().expand()
+                    wrapper.setActor<Label>(
+                        Label(strings["loading-screen.loading"], styles.label.medium).apply {
+                            color.a
+                            addAction(
+                                Actions.sequence(
+                                    Actions.delay(0.5f),
+                                    Actions.fadeIn(0.2f),
+                                )
+                            )
+                        }
+                    )
+                }
+            ).apply {
+                setFillParent(true)
+                setScrollingDisabled(true, false)
+                setupOverscroll(width / 4, 30f, 200f)
             }
         )
 
-        credits(strings).entries.forEach { entry ->
+        scope.launch {
+            val worlds = loadAllWorlds()
+            onRenderingThread {
+                wrapper.setActor(
+                    VerticalGroup().also { container ->
 
-            val heading = entry.key
-            val values = entry.value
+                        container.space(UI_SPACE)
 
-            container.addActor(
-                Label(heading, styles.label.large).apply {
-                    setAlignment(Align.center)
-                }
-            )
+                        credits(strings, worlds).entries.forEach { entry ->
 
-            values.forEach { value ->
+                            val heading = entry.key
+                            val values = entry.value
 
-                container.addActor(
-                    Label(value, styles.label.medium).apply {
-                        setAlignment(Align.center)
+                            container.addActor(
+                                Label(heading, styles.label.large).apply {
+                                    setAlignment(Align.center)
+                                }
+                            )
+
+                            values.entries.forEach { (label, url) ->
+
+                                container.addActor(
+                                    Label(label, styles.label.medium).apply {
+                                        setAlignment(Align.center)
+                                        touchable = Touchable.enabled
+                                        onClick {
+                                            Gdx.net.openURI(url)
+                                        }
+                                    }
+                                )
+
+                            }
+                        }
                     }
                 )
-
             }
         }
-
-        stage.addActor(container)
 
     }
 
@@ -90,25 +138,23 @@ class AboutScreen(private val game: BeatFeetGame): ScreenAdapter() {
         stage.draw()
     }
 
-    companion object {
-        private fun credits(strings: I18NBundle) = mapOf(
+    private fun credits(strings: I18NBundle, worlds: List<World>) = mapOf(
 
-            // Intentionally leave these un-internationalised, because they need to refer back
-            // to the original source and license to avoid ambiguity
+        // Intentionally leave these un-internationalised, because they need to refer back
+        // to the original source and license to avoid ambiguity
 
-            strings["about.credits.music"] to listOf(
-                strings["about.credits.music-the-haunted-mansion"],
-                strings["about.credits.music-awakening"],
-                strings["about.credits.music-health-and-safety"],
-                strings["about.credits.music-john-harrison-wichita-state-university-chamber"],
-            ),
+        strings["about.credits.graphics"] to mapOf(
+            strings["about.credits.graphics-kenney"] to "https://kenney.nl",
+            strings["about.credits.graphics-disabledpaladin"] to "https://www.deviantart.com/disabledpaladin",
+        ),
 
-            strings["about.credits.graphics"] to listOf(
-                strings["about.credits.graphics-kenney"],
-                strings["about.credits.graphics-disabledpaladin"],
-            )
+        strings["about.credits.music"] to worlds
+            .map { it.getAttribution() }
+            .flatten()
+            .associate {
+                listOfNotNull(it.name, it.author, it.license).joinToString(" / ") to it.sourceUrl
+            },
 
-        )
-    }
+    )
 
 }

--- a/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
@@ -104,7 +104,7 @@ class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
         val achievementsTable = Table()
 
         allAchievements.forEachIndexed { i, achievement ->
-            val isAchieved = achievements.any { it.level == level && it.type.id == achievement.id }
+            val isAchieved = achievements.any { it.levelId == level.getId() && it.type.id == achievement.id }
             val label = Label(strings["achievement.${achievement.id}"], styles.label.small)
             label.color = if (isAchieved) Color.WHITE else Color.GRAY
 

--- a/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
@@ -4,6 +4,8 @@ import com.badlogic.gdx.*
 import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.badlogic.gdx.scenes.scene2d.ui.Container
 import com.badlogic.gdx.scenes.scene2d.ui.Label
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane
 import com.badlogic.gdx.scenes.scene2d.ui.Table
@@ -13,38 +15,29 @@ import com.serwylo.beatgame.Assets
 import com.serwylo.beatgame.BeatFeetGame
 import com.serwylo.beatgame.levels.TheOriginalWorld
 import com.serwylo.beatgame.levels.Level
+import com.serwylo.beatgame.levels.World
 import com.serwylo.beatgame.levels.achievements.Achievement
 import com.serwylo.beatgame.levels.achievements.allAchievements
 import com.serwylo.beatgame.levels.achievements.loadAllAchievements
+import com.serwylo.beatgame.levels.loadAllWorlds
 import com.serwylo.beatgame.ui.UI_SPACE
 import com.serwylo.beatgame.ui.makeHeading
 import com.serwylo.beatgame.ui.makeStage
+import com.serwylo.beatgame.ui.makeWorldSelector
+import kotlinx.coroutines.*
 
-class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
+class AchievementsScreen(private val game: BeatFeetGame): WorldSelectorScreen(
+    game,
+    "achievements.title",
+    game.assets.getSprites().star,
+    TheOriginalWorld,
+) {
 
-    private val stage = makeStage()
-    private val world = TheOriginalWorld
+    override fun makeBody(world: World) = Table().also { table ->
 
-    init {
-        setupStage()
-    }
-
-    private fun setupStage() {
         val achievements = loadAllAchievements()
 
-        val styles = game.assets.getStyles()
-        val sprites = game.assets.getSprites()
-        val strings = game.assets.getStrings()
-
-        val table = Table()
-        table.padBottom(UI_SPACE * 2)
-        table.row().align(Align.center).pad(UI_SPACE * 2)
-
-        val headingGroup = makeHeading(strings["achievements.title"], sprites.star, styles, strings) {
-            game.showMenu()
-        }
-
-        table.add(headingGroup).colspan(2)
+        table.pad(UI_SPACE)
 
         world.getLevels().forEach { level ->
 
@@ -80,23 +73,7 @@ class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
             table.add(achievementsWidget).apply {
                 align(Align.left or Align.top)
             }
-
         }
-
-        stage.addActor(
-            ScrollPane(table).apply {
-                setFillParent(true)
-                setScrollingDisabled(true, false)
-                setupOverscroll(UI_SPACE, 30f, 200f)
-            }
-        )
-
-    }
-
-    override fun resize(width: Int, height: Int) {
-        stage.viewport.update(width, height, true)
-        stage.clear()
-        setupStage()
     }
 
     private fun makeAchievementsTable(styles: Assets.Styles, strings: I18NBundle, achievements: List<Achievement>, level: Level): Actor {
@@ -116,40 +93,6 @@ class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
         }
 
         return achievementsTable
-
-    }
-
-    override fun show() {
-        super.show()
-
-        Gdx.input.setCatchKey(Input.Keys.BACK, true)
-        Gdx.input.inputProcessor = InputMultiplexer(stage, object : InputAdapter() {
-
-            override fun keyDown(keycode: Int): Boolean {
-                if (keycode == Input.Keys.ESCAPE || keycode == Input.Keys.BACK) {
-                    game.showMenu()
-                    return true
-                }
-
-                return false
-            }
-
-        })
-
-    }
-
-    override fun hide() {
-        Gdx.input.inputProcessor = null
-        Gdx.input.setCatchKey(Input.Keys.BACK, false)
-    }
-
-    override fun render(delta: Float) {
-
-        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
-
-        stage.act(delta)
-        stage.draw()
 
     }
 

--- a/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
@@ -47,9 +47,9 @@ class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
         Levels.all.forEach { level ->
 
-            val isLocked = level.unlockRequirements.isLocked(achievements)
+            val isLocked = level.getUnlockRequirements().isLocked(achievements)
             val textColor = if (isLocked) Color.GRAY else Color.WHITE
-            val labelString = if (isLocked && !level.unlockRequirements.isAlmostUnlocked(achievements)) "???" else strings[level.labelId]
+            val labelString = if (isLocked && !level.getUnlockRequirements().isAlmostUnlocked(achievements)) "???" else level.getLabel(strings)
 
             val levelLabel = Label(labelString, styles.label.medium).apply {
                 setAlignment(Align.right)
@@ -71,7 +71,7 @@ class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
             val achievementsWidget: Actor = if (!isLocked) {
                 makeAchievementsTable(styles, strings, achievements, level)
             } else {
-                val toUnlockLabel = Label(strings.format("achievements.unlock-requirements", level.unlockRequirements.describeOutstandingRequirements(strings, achievements)), styles.label.small)
+                val toUnlockLabel = Label(strings.format("achievements.unlock-requirements", level.getUnlockRequirements().describeOutstandingRequirements(strings, achievements)), styles.label.small)
                 toUnlockLabel.color = Color.GRAY
                 toUnlockLabel
             }

--- a/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/AchievementsScreen.kt
@@ -11,8 +11,8 @@ import com.badlogic.gdx.utils.Align
 import com.badlogic.gdx.utils.I18NBundle
 import com.serwylo.beatgame.Assets
 import com.serwylo.beatgame.BeatFeetGame
+import com.serwylo.beatgame.levels.TheOriginalWorld
 import com.serwylo.beatgame.levels.Level
-import com.serwylo.beatgame.levels.Levels
 import com.serwylo.beatgame.levels.achievements.Achievement
 import com.serwylo.beatgame.levels.achievements.allAchievements
 import com.serwylo.beatgame.levels.achievements.loadAllAchievements
@@ -23,6 +23,7 @@ import com.serwylo.beatgame.ui.makeStage
 class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
     private val stage = makeStage()
+    private val world = TheOriginalWorld
 
     init {
         setupStage()
@@ -45,7 +46,7 @@ class AchievementsScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
         table.add(headingGroup).colspan(2)
 
-        Levels.all.forEach { level ->
+        world.getLevels().forEach { level ->
 
             val isLocked = level.getUnlockRequirements().isLocked(achievements)
             val textColor = if (isLocked) Color.GRAY else Color.WHITE

--- a/core/src/com/serwylo/beatgame/screens/ExplainCustomSongsScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/ExplainCustomSongsScreen.kt
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.utils.Align
 import com.serwylo.beatgame.BeatFeetGame
 import com.serwylo.beatgame.audio.customMp3
+import com.serwylo.beatgame.levels.TheOriginalWorld
 import com.serwylo.beatgame.ui.UI_SPACE
 import com.serwylo.beatgame.ui.makeButton
 import com.serwylo.beatgame.ui.makeHeading
@@ -27,7 +28,7 @@ class ExplainCustomSongsScreen(private val game: BeatFeetGame): ScreenAdapter() 
             pad(UI_SPACE * 2)
 
             val title = makeHeading(strings["custom-songs.title"], sprites.logo, styles, strings) {
-                game.showLevelSelectMenu()
+                game.showLevelSelectMenu(TheOriginalWorld)
             }
 
             row()

--- a/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
@@ -9,18 +9,14 @@ import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Align
 import com.serwylo.beatgame.BeatFeetGame
-import com.serwylo.beatgame.audio.customMp3
-import com.serwylo.beatgame.levels.Level
-import com.serwylo.beatgame.levels.Levels
+import com.serwylo.beatgame.levels.*
 import com.serwylo.beatgame.levels.achievements.loadAllAchievements
-import com.serwylo.beatgame.levels.loadHighScore
 import com.serwylo.beatgame.ui.UI_SPACE
 import com.serwylo.beatgame.ui.makeHeading
 import com.serwylo.beatgame.ui.makeIcon
 import com.serwylo.beatgame.ui.makeStage
-import java.io.File
 
-class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
+class LevelSelectScreen(private val game: BeatFeetGame, private val world: World): ScreenAdapter() {
 
     private val stage = makeStage()
 
@@ -75,7 +71,7 @@ class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
         container.addActor(table)
 
-        Levels.all.forEachIndexed { i, level ->
+        world.getLevels().forEachIndexed { i, level ->
 
             if (i % levelsPerRow == 0) {
                 table.row()
@@ -200,15 +196,15 @@ class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
     }
 
     fun onLevelSelected(level: Level): Boolean {
-        if (level.getId() == "custom.mp3") {
-            val file = customMp3()
+        if (level === CustomLevel) {
+            val file = level.getMp3File()
             if (!file.exists()) {
                 game.explainCustomSongs()
             } else {
-                game.loadGame(file, "{Custom}")
+                game.loadGame(level)
             }
         } else {
-            game.loadGame(level.getMp3File(), level.getLabel(strings))
+            game.loadGame(level)
         }
 
         return true

--- a/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
@@ -11,12 +11,11 @@ import com.badlogic.gdx.utils.Align
 import com.serwylo.beatgame.BeatFeetGame
 import com.serwylo.beatgame.levels.*
 import com.serwylo.beatgame.levels.achievements.loadAllAchievements
-import com.serwylo.beatgame.ui.UI_SPACE
-import com.serwylo.beatgame.ui.makeHeading
-import com.serwylo.beatgame.ui.makeIcon
-import com.serwylo.beatgame.ui.makeStage
+import com.serwylo.beatgame.ui.*
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
-class LevelSelectScreen(private val game: BeatFeetGame, private val world: World): ScreenAdapter() {
+class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld: World): ScreenAdapter() {
 
     private val stage = makeStage()
 
@@ -30,21 +29,10 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val world: World
 
     private val achievements = loadAllAchievements()
 
+    private val header = Container<Actor>()
+    private val body = Container<Actor>()
+
     init {
-        setupStage()
-    }
-
-    private fun setupStage() {
-        // Later on, do some proper responsive sizing. However my first attempts struggled with
-        // density independent pixel calculations (even though the math is simple, it didn't
-        // seem to set proper breakpoints, perhaps because of the arbitrary math in calcDensityScaleFactor()
-        // from before it occurred we could use DIPs).
-        val levelsPerRow = if (Gdx.app.type == Application.ApplicationType.Desktop) 5 else 4
-        val width = (stage.width - UI_SPACE * 2) / levelsPerRow
-        val height = width * 3 / 4
-
-        var x = 0
-        var y = 0
 
         val container = VerticalGroup().apply {
             space(UI_SPACE)
@@ -65,26 +53,96 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val world: World
             }
         )
 
-        val table = Table().apply {
-            pad(UI_SPACE)
-        }
+        container.addActor(header)
+        container.addActor(body)
 
-        container.addActor(table)
+        setupStage(initialWorld)
 
-        world.getLevels().forEachIndexed { i, level ->
+    }
 
-            if (i % levelsPerRow == 0) {
-                table.row()
-                y ++
-                x = 0
+    private fun setupStage(world: World) {
+
+        header.actor = makeWorldSelector(
+            strings,
+            styles,
+            world,
+            onPrevious = if (world === TheOriginalWorld) null else { -> onPreviousWorld(world) },
+            onNext = { onNextWorld(world) },
+        )
+
+        body.actor = Table().also { table ->
+            table.pad(UI_SPACE)
+
+            // Later on, do some proper responsive sizing. However my first attempts struggled with
+            // density independent pixel calculations (even though the math is simple, it didn't
+            // seem to set proper breakpoints, perhaps because of the arbitrary math in calcDensityScaleFactor()
+            // from before it occurred we could use DIPs).
+            val levelsPerRow = if (Gdx.app.type == Application.ApplicationType.Desktop) 5 else 4
+            val width = (stage.width - UI_SPACE * 2) / levelsPerRow
+            val height = width * 3 / 4
+
+            var x = 0
+            var y = 0
+
+            world.getLevels().forEachIndexed { i, level ->
+
+                if (i % levelsPerRow == 0) {
+                    table.row()
+                    y ++
+                    x = 0
+                }
+
+                table.add(makeButton(level)).width(width).height(height)
+
+                x ++
+
             }
-
-            table.add(makeButton(level)).width(width).height(height)
-
-            x ++
-
         }
 
+    }
+
+    private var cachedWorlds: List<World>? = null
+
+    private suspend fun allWorlds(): List<World> {
+        return cachedWorlds ?: loadAllWorlds().also { newlyLoaded ->
+            cachedWorlds = newlyLoaded
+        }
+    }
+
+    private fun onPreviousWorld(currentWorld: World?) {
+        if (currentWorld === TheOriginalWorld) {
+            return
+        }
+
+        GlobalScope.launch {
+            val worlds = allWorlds()
+            if (currentWorld == null) {
+                setupStage(worlds.last())
+            } else {
+                val currentIndex = worlds.indexOfFirst { it.getId() == currentWorld.getId() }
+                if (currentIndex > 0) {
+                    setupStage(worlds[currentIndex - 1])
+                }
+            }
+        }
+    }
+
+    private fun onNextWorld(currentWorld: World) {
+        GlobalScope.launch {
+            val worlds = allWorlds()
+            val currentIndex = worlds.indexOfFirst { it.getId() == currentWorld.getId() }
+            if (currentIndex < worlds.size - 1) {
+                setupStage(worlds[currentIndex + 1])
+            } else {
+                showComingSoon()
+            }
+        }
+    }
+
+    private fun showComingSoon() {
+        header.actor = makeWorldSelector(strings, styles, null, onPrevious = {
+            onPreviousWorld(null)
+        })
     }
 
     override fun show() {
@@ -112,8 +170,7 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val world: World
 
     override fun resize(width: Int, height: Int) {
         stage.viewport.update(width, height, true)
-        stage.clear()
-        setupStage()
+        setupStage(initialWorld)
     }
 
     override fun render(delta: Float) {

--- a/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
@@ -136,7 +136,7 @@ class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
     private fun makeButton(level: Level): WidgetGroup {
 
-        val isLocked = level.unlockRequirements.isLocked(achievements)
+        val isLocked = level.getUnlockRequirements().isLocked(achievements)
         val buttonStyle = if (isLocked) "locked" else "default"
         val textColor = if (isLocked) Color.GRAY else Color.WHITE
 
@@ -150,7 +150,7 @@ class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
             })
         }
 
-        val labelString = if (isLocked && !level.unlockRequirements.isAlmostUnlocked(achievements)) "???" else strings[level.labelId]
+        val labelString = if (isLocked && !level.getUnlockRequirements().isAlmostUnlocked(achievements)) "???" else level.getLabel(strings)
 
         val levelLabel = Label(labelString, styles.label.medium).apply {
             wrap = true
@@ -170,7 +170,7 @@ class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
         if (isLocked) {
 
-            val unlockDescription = Label(level.unlockRequirements.describeOutstandingRequirements(strings, achievements), styles.label.small)
+            val unlockDescription = Label(level.getUnlockRequirements().describeOutstandingRequirements(strings, achievements), styles.label.small)
             unlockDescription.color = textColor
 
             table.row()
@@ -200,7 +200,7 @@ class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
     }
 
     fun onLevelSelected(level: Level): Boolean {
-        if (level.mp3Name == "custom.mp3") {
+        if (level.getId() == "custom.mp3") {
             val file = customMp3()
             if (!file.exists()) {
                 game.explainCustomSongs()
@@ -208,7 +208,7 @@ class LevelSelectScreen(private val game: BeatFeetGame): ScreenAdapter() {
                 game.loadGame(file, "{Custom}")
             }
         } else {
-            game.loadGame(Gdx.files.internal("songs${File.separator}mp3${File.separator}${level.mp3Name}"), strings[level.labelId])
+            game.loadGame(level.getMp3File(), level.getLabel(strings))
         }
 
         return true

--- a/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
@@ -153,10 +153,6 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
         }
     }
 
-    private fun createLoadingMessage(): Actor {
-        return Label(strings["loading-screen.loading"], styles.label.medium)
-    }
-
     private suspend fun <T>performSlowOperation(block: suspend () -> T): T = withContext(Dispatchers.IO) {
         header.actor.addAction(
             Actions.sequence(
@@ -170,8 +166,11 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
                 Actions.delay(0.5f),
                 Actions.fadeOut(0.2f),
                 Actions.run {
-                    body.actor = createLoadingMessage()
-                    body.actor.addAction(Actions.fadeIn(0.2f))
+                    body.pad(UI_SPACE * 4)
+                    body.actor = Label(strings["loading-screen.loading"], styles.label.medium).also { label ->
+                        label.setAlignment(Align.center)
+                        label.addAction(Actions.fadeIn(0.2f))
+                    }
                 },
             )
         )
@@ -180,6 +179,7 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
 
         header.actor.clearActions()
         body.actor.clearActions()
+        body.pad(0f)
 
         header.actor.color.a = 1f
         body.actor.color.a = 1f
@@ -200,7 +200,7 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
                     label.wrap = true
                     label.setAlignment(Align.center)
                 }
-            ).pad(UI_SPACE).expandX().fill(0.5f, 0f)
+            ).pad(UI_SPACE).expandX().fill(0.75f, 0f)
             row().pad(UI_SPACE)
 
             add(
@@ -208,7 +208,7 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
                     label.wrap = true
                     label.setAlignment(Align.center)
                 }
-            ).pad(UI_SPACE).expandX().fill(0.4f, 0f)
+            ).pad(UI_SPACE).expandX().fill(0.6f, 0f)
             row().pad(UI_SPACE)
 
             add(makeButton(strings["level-select.more-coming-soon.suggest-a-song"], styles) {

--- a/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/LevelSelectScreen.kt
@@ -2,85 +2,29 @@ package com.serwylo.beatgame.screens
 
 import com.badlogic.gdx.*
 import com.badlogic.gdx.graphics.Color
-import com.badlogic.gdx.graphics.GL20
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Touchable
-import com.badlogic.gdx.scenes.scene2d.actions.Actions
 import com.badlogic.gdx.scenes.scene2d.ui.*
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
 import com.badlogic.gdx.utils.Align
 import com.serwylo.beatgame.BeatFeetGame
 import com.serwylo.beatgame.levels.*
+import com.serwylo.beatgame.levels.achievements.Achievement
 import com.serwylo.beatgame.levels.achievements.loadAllAchievements
 import com.serwylo.beatgame.ui.*
-import kotlinx.coroutines.*
 
-class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld: World): ScreenAdapter() {
+class LevelSelectScreen(private val game: BeatFeetGame, initialWorld: World): WorldSelectorScreen(
+    game,
+    "level-select.title",
+    game.assets.getSprites().logo,
+    initialWorld,
+) {
 
-    private val stage = makeStage()
+    override fun makeBody(world: World) =
+        Table().also { table ->
 
-    private val sprites = game.assets.getSprites()
-    private val styles = game.assets.getStyles()
-    private val skin = game.assets.getSkin()
-    private val strings = game.assets.getStrings()
+            val achievements = loadAllAchievements()
 
-    private val distanceTexture = sprites.right_sign
-    private val scoreTexture = sprites.score
-
-    private val achievements = loadAllAchievements()
-
-    private val header = Container<Actor>()
-    private val body = Container<Actor>()
-
-    private val job = Job()
-    private val scope = CoroutineScope(Dispatchers.IO + job)
-
-    init {
-
-        val container = Table().apply {
-            pad(UI_SPACE)
-            padTop(UI_SPACE * 2)
-        }
-
-        val scrollPane = ScrollPane(container, skin).apply {
-            setFillParent(true)
-            setScrollingDisabled(true, false)
-            setupOverscroll(width / 4, 30f, 200f)
-        }
-
-        stage.addActor(scrollPane)
-
-        container.add(
-            makeHeading(strings["level-select.title"], sprites.logo, styles, strings) {
-                game.showMenu()
-            }
-        ).top()
-        container.row()
-
-        container.add(header)
-        container.row()
-
-        container.add(body).expand().fillX().top()
-        container.row()
-
-        body.fill()
-
-        setupStage(initialWorld)
-
-    }
-
-    private fun setupStage(world: World) {
-
-        header.actor = makeWorldSelector(
-            strings,
-            styles,
-            world,
-            onPrevious = if (world === TheOriginalWorld) null else { -> onPreviousWorld(world) },
-            onNext = { onNextWorld(world) },
-        )
-
-        Gdx.app.log("LevelSelectScreen", "Viewing level list")
-        body.actor = Table().also { table ->
             table.pad(UI_SPACE)
 
             // Later on, do some proper responsive sizing. However my first attempts struggled with
@@ -102,195 +46,16 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
                     x = 0
                 }
 
-                table.add(makeButton(level)).width(width).height(height)
+                table.add(makeButton(level, achievements)).width(width).height(height)
 
                 x ++
 
             }
         }
-    }
 
-    private var cachedWorlds: List<World>? = null
+    private fun makeButton(level: Level, allAchievements: List<Achievement>): WidgetGroup {
 
-    private suspend fun allWorlds(): List<World> {
-        return cachedWorlds ?: loadAllWorlds().also { newlyLoaded ->
-            cachedWorlds = newlyLoaded
-        }
-    }
-
-    private fun onPreviousWorld(currentWorld: World?) {
-        if (currentWorld === TheOriginalWorld) {
-            return
-        }
-
-        scope.launch {
-            val worlds = performSlowOperation {
-                allWorlds()
-            }
-            if (currentWorld == null) {
-                setupStage(worlds.last())
-            } else {
-                val currentIndex = worlds.indexOfFirst { it.getId() == currentWorld.getId() }
-                if (currentIndex > 0) {
-                    setupStage(worlds[currentIndex - 1])
-                }
-            }
-        }
-    }
-
-    private fun onNextWorld(currentWorld: World) {
-        scope.launch {
-            val worlds = performSlowOperation {
-                allWorlds()
-            }
-
-            val currentIndex = worlds.indexOfFirst { it.getId() == currentWorld.getId() }
-            if (currentIndex < worlds.size - 1) {
-                setupStage(worlds[currentIndex + 1])
-            } else {
-                showComingSoon(worlds)
-            }
-        }
-    }
-
-    private suspend fun <T>performSlowOperation(block: suspend () -> T): T = withContext(Dispatchers.IO) {
-        header.actor.addAction(
-            Actions.sequence(
-                Actions.delay(0.5f),
-                Actions.fadeOut(0.2f),
-            )
-        )
-
-        body.actor.addAction(
-            Actions.sequence(
-                Actions.delay(0.5f),
-                Actions.fadeOut(0.2f),
-                Actions.run {
-                    body.pad(UI_SPACE * 4)
-                    body.actor = Label(strings["loading-screen.loading"], styles.label.medium).also { label ->
-                        label.setAlignment(Align.center)
-                        label.addAction(Actions.fadeIn(0.2f))
-                    }
-                },
-            )
-        )
-
-        val result = block()
-
-        header.actor.clearActions()
-        body.actor.clearActions()
-        body.pad(0f)
-
-        header.actor.color.a = 1f
-        body.actor.color.a = 1f
-
-        result
-    }
-
-    private fun showComingSoon(knownWorlds: List<World>) {
-        header.actor = makeWorldSelector(strings, styles, null, onPrevious = {
-            onPreviousWorld(null)
-        })
-
-        body.actor = Table().apply {
-            pad(UI_SPACE)
-            padTop(UI_SPACE * 4)
-            add(
-                Label(strings["level-select.more-coming-soon.ask-for-recommendations"], styles.label.medium).also { label ->
-                    label.wrap = true
-                    label.setAlignment(Align.center)
-                }
-            ).pad(UI_SPACE).expandX().fill(0.75f, 0f).colspan(2)
-            row().pad(UI_SPACE)
-
-            add(
-                Label(strings["level-select.more-coming-soon.when-we-find-time"], styles.label.small).also { label ->
-                    label.wrap = true
-                    label.setAlignment(Align.center)
-                }
-            ).pad(UI_SPACE).expandX().fill(0.6f, 0f).colspan(2)
-            row().pad(UI_SPACE)
-
-            add(
-                makeButton(strings["level-select.more-coming-soon.suggest-a-song"], styles) {
-                    Gdx.net.openURI("https://github.com/beat-feet/beat-feet/issues/new?title=Song%20suggestion:%20&labels=song+suggestion&body=(PLEASE%20NOTE:%20This%20game%20is%20open%20source,%20and%20all%20songs%20included%20in%20it%20must%20be%20freely%20licensed,%20for%20example,%20CC-BY)")
-                }
-            ).pad(UI_SPACE).right()
-
-            add(
-                makeButton("Check for new levels", styles) {
-                    refreshLevels(knownWorlds)
-                }
-            ).pad(UI_SPACE).left()
-        }
-
-    }
-
-    private fun refreshLevels(knownWorlds: List<World>) {
-        scope.launch {
-            val newWorlds = performSlowOperation {
-                loadAllWorlds(forceUncached = true).also { newlyLoaded ->
-                    cachedWorlds = newlyLoaded
-                }
-            }
-
-            val oldLevelCount = knownWorlds.sumOf { it.getLevels().size }
-            val newLevelCount = newWorlds.sumOf { it.getLevels().size }
-
-            when {
-                newWorlds.size > knownWorlds.size -> setupStage(newWorlds[knownWorlds.size])
-                oldLevelCount != newLevelCount -> setupStage(newWorlds.last())
-                else -> showComingSoon(newWorlds)
-            }
-        }
-    }
-
-    override fun show() {
-
-        Gdx.input.setCatchKey(Input.Keys.BACK, true)
-        Gdx.input.inputProcessor = InputMultiplexer(stage, object : InputAdapter() {
-
-            override fun keyDown(keycode: Int): Boolean {
-                if (keycode == Input.Keys.ESCAPE || keycode == Input.Keys.BACK) {
-                    game.showMenu()
-                    return true
-                }
-
-                return false
-            }
-
-        })
-
-    }
-
-    override fun hide() {
-        Gdx.input.inputProcessor = null
-        Gdx.input.setCatchKey(Input.Keys.BACK, false)
-    }
-
-    override fun resize(width: Int, height: Int) {
-        stage.viewport.update(width, height, true)
-        setupStage(initialWorld)
-    }
-
-    override fun render(delta: Float) {
-
-        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
-
-        stage.act(delta)
-        stage.draw()
-
-    }
-
-    override fun dispose() {
-        stage.dispose()
-        scope.cancel()
-    }
-
-    private fun makeButton(level: Level): WidgetGroup {
-
-        val isLocked = level.getUnlockRequirements().isLocked(achievements)
+        val isLocked = level.getUnlockRequirements().isLocked(allAchievements)
         val buttonStyle = if (isLocked) "locked" else "default"
         val textColor = if (isLocked) Color.GRAY else Color.WHITE
 
@@ -304,7 +69,7 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
             })
         }
 
-        val labelString = if (isLocked && !level.getUnlockRequirements().isAlmostUnlocked(achievements)) "???" else level.getLabel(strings)
+        val labelString = if (isLocked && !level.getUnlockRequirements().isAlmostUnlocked(allAchievements)) "???" else level.getLabel(strings)
 
         val levelLabel = Label(labelString, styles.label.medium).apply {
             wrap = true
@@ -324,7 +89,7 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
 
         if (isLocked) {
 
-            val unlockDescription = Label(level.getUnlockRequirements().describeOutstandingRequirements(strings, achievements), styles.label.small)
+            val unlockDescription = Label(level.getUnlockRequirements().describeOutstandingRequirements(strings, allAchievements), styles.label.small)
             unlockDescription.color = textColor
 
             table.row()
@@ -335,8 +100,8 @@ class LevelSelectScreen(private val game: BeatFeetGame, private val initialWorld
             val distanceLabel = Label(highScore.distancePercentString(), styles.label.small)
             val scoreLabel = Label(highScore.points.toString(), styles.label.small)
 
-            val distanceIcon = makeIcon(distanceTexture)
-            val scoreIcon = makeIcon(scoreTexture)
+            val distanceIcon = makeIcon(sprites.right_sign)
+            val scoreIcon = makeIcon(sprites.score)
 
             val iconSize = Value.percentWidth(0.75f)
             val iconSpace = Value.percentWidth(0.2f)

--- a/core/src/com/serwylo/beatgame/screens/LoadingScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/LoadingScreen.kt
@@ -98,19 +98,24 @@ class LoadingScreen(
             val levelData: LevelData = when (level) {
 
                 is RemoteLevel -> {
-                    loadingLabel.setText(strings["loading-screen.downloading-song"])
-                    level.ensureMp3Downloaded()
+                    if (!level.getMp3File().exists()) {
+                        loadingLabel.setText(strings["loading-screen.downloading-song"])
+                        level.ensureMp3Downloaded()
+                    }
 
-                    loadingLabel.setText(strings["loading-screen.downloading-level"])
-                    level.ensureLevelDataDownloaded()
+                    val levelDataFile = level.getLevelDataFile()
+                    if (!levelDataFile.exists()) {
+                        loadingLabel.setText(strings["loading-screen.downloading-level"])
+                        level.ensureLevelDataDownloaded()
+                    }
 
-                    loadCachedLevelData(level.getLevelDataFile())
+                    loadCachedLevelData(levelDataFile)
                 }
 
                 is CustomLevel -> {
                     val file = level.getLevelDataFile()
                     if (!file.exists()) {
-                        loadingLabel.setText(strings.format("loading-screen.analysing-mp3", level.getMp3File().file().absolutePath) + "\n" + strings["loading-screen.custom-song-warning"])
+                        loadingLabel.setText(strings["loading-screen.analysing-mp3"] + "\n" + level.getMp3File().file().absolutePath + "\n" + strings["loading-screen.custom-song-warning"])
                         loadLevelDataFromMp3(level.getMp3File())
                     } else {
                         loadCachedLevelData(file)

--- a/core/src/com/serwylo/beatgame/screens/LoadingScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/LoadingScreen.kt
@@ -27,7 +27,7 @@ class LoadingScreen(
 
     private val stage = makeStage()
 
-    private val level = Levels.bySong(musicFile.name())
+    private val level = Levels.byId(musicFile.name())
 
     init {
         val sprites = game.assets.getSprites()

--- a/core/src/com/serwylo/beatgame/screens/MainMenuScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/MainMenuScreen.kt
@@ -8,6 +8,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table
 import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup
 import com.badlogic.gdx.utils.Align
 import com.serwylo.beatgame.BeatFeetGame
+import com.serwylo.beatgame.levels.TheOriginalWorld
 import com.serwylo.beatgame.ui.*
 
 class MainMenuScreen(private val game: BeatFeetGame): ScreenAdapter() {
@@ -31,7 +32,7 @@ class MainMenuScreen(private val game: BeatFeetGame): ScreenAdapter() {
 
         val buttonTable = Table()
 
-        val playButton = makeLargeButton(strings["main-menu.btn.play"], styles) { game.showLevelSelectMenu() }
+        val playButton = makeLargeButton(strings["main-menu.btn.play"], styles) { game.showLevelSelectMenu(TheOriginalWorld) }
         val achievementsButton = makeButton(strings["main-menu.btn.achievements"], styles) { game.showAchievements() }
         val aboutButton = makeButton(strings["main-menu.btn.about"], styles) { game.showAboutScreen() }
 

--- a/core/src/com/serwylo/beatgame/screens/PlatformGameScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/PlatformGameScreen.kt
@@ -14,7 +14,7 @@ import com.serwylo.beatgame.BeatFeetGame
 import com.serwylo.beatgame.Globals
 import com.serwylo.beatgame.HUD
 import com.serwylo.beatgame.audio.features.Feature
-import com.serwylo.beatgame.audio.features.World
+import com.serwylo.beatgame.audio.features.LevelData
 import com.serwylo.beatgame.entities.*
 import com.serwylo.beatgame.graphics.TiledSprite
 import com.serwylo.beatgame.graphics.calcDensityScaleFactor
@@ -30,14 +30,14 @@ import kotlin.math.sin
 
 class PlatformGameScreen(
     private val game: BeatFeetGame,
-    private val world: World
+    private val levelData: LevelData
 ) : ScreenAdapter() {
 
     private val camera = makeCamera(20, 10, calcDensityScaleFactor())
     private lateinit var hud: HUD
     private val obstacles = mutableListOf<Obstacle>()
 
-    private val music = Gdx.audio.newMusic(world.musicFile)
+    private val music = Gdx.audio.newMusic(levelData.musicFile)
 
     /**
      * Used at the end of the game to show feedback about the level and also a few options for
@@ -80,9 +80,9 @@ class PlatformGameScreen(
         val sprites = game.assets.getSprites()
 
         val allFeatures = mutableListOf<Feature>()
-        allFeatures.addAll(world.featuresLow)
-        allFeatures.addAll(world.featuresMid)
-        allFeatures.addAll(world.featuresHigh)
+        allFeatures.addAll(levelData.featuresLow)
+        allFeatures.addAll(levelData.featuresMid)
+        allFeatures.addAll(levelData.featuresHigh)
 
         obstacles.addAll(generateObstacles(sprites, allFeatures))
 
@@ -233,7 +233,7 @@ class PlatformGameScreen(
             renderEntities()
         }
 
-        score.progress((playTime / world.duration).coerceAtMost(1f))
+        score.progress((playTime / levelData.duration).coerceAtMost(1f))
 
         hud.render(delta, player.getHealth(), player.getShield())
 
@@ -298,7 +298,7 @@ class PlatformGameScreen(
 
             }
 
-            if (player.position.x >= (world.duration + WARM_UP_TIME + END_LEVEL_WALK_TIME) * SCALE_X) {
+            if (player.position.x >= (levelData.duration + WARM_UP_TIME + END_LEVEL_WALK_TIME) * SCALE_X) {
 
                 state = State.WINNING
                 successPlayer.setup(player.position)
@@ -439,7 +439,7 @@ class PlatformGameScreen(
         val pauseGameInfo = PauseGameActor(
             game,
             { resume() },
-            { leaveGame { game.startGame(world) } },
+            { leaveGame { game.startGame(levelData) } },
             { leaveGame { game.showLevelSelectMenu() } },
             { leaveGame { game.showMenu() } }
         )
@@ -495,10 +495,10 @@ class PlatformGameScreen(
     private fun endGame() {
         music.volume = 0.4f
 
-        val existingAchievements = loadAchievementsForLevel(world.level())
+        val existingAchievements = loadAchievementsForLevel(levelData.level())
         val newAchievements: List<AchievementType>
-        val existingHighScore: HighScore = loadHighScore(world.level())
-        val newHighScore: HighScore = saveHighScore(world.level(), score)
+        val existingHighScore: HighScore = loadHighScore(levelData.level())
+        val newHighScore: HighScore = saveHighScore(levelData.level(), score)
 
         saveHasPerformedDoubleJump(player.hasPerformedDoubleJump())
 
@@ -506,7 +506,7 @@ class PlatformGameScreen(
             it.isAchieved(score, newHighScore) && existingAchievements.all { existing -> existing.id != it.id }
         }
 
-        saveAchievements(world.level(), newAchievements)
+        saveAchievements(levelData.level(), newAchievements)
 
         val leaveGame = { subsequentAction: () -> Unit -> {
             music.stop()
@@ -518,7 +518,7 @@ class PlatformGameScreen(
             existingHighScore,
             score,
             newAchievements,
-            leaveGame { game.startGame(world) },
+            leaveGame { game.startGame(levelData) },
             leaveGame { game.showLevelSelectMenu() },
             leaveGame { game.showMenu() }
         )

--- a/core/src/com/serwylo/beatgame/screens/WorldSelectorScreen.kt
+++ b/core/src/com/serwylo/beatgame/screens/WorldSelectorScreen.kt
@@ -1,0 +1,270 @@
+package com.serwylo.beatgame.screens
+
+import com.badlogic.gdx.*
+import com.badlogic.gdx.graphics.Color
+import com.badlogic.gdx.graphics.GL20
+import com.badlogic.gdx.graphics.g2d.TextureRegion
+import com.badlogic.gdx.scenes.scene2d.Actor
+import com.badlogic.gdx.scenes.scene2d.Touchable
+import com.badlogic.gdx.scenes.scene2d.actions.Actions
+import com.badlogic.gdx.scenes.scene2d.ui.*
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener
+import com.badlogic.gdx.utils.Align
+import com.serwylo.beatgame.BeatFeetGame
+import com.serwylo.beatgame.levels.*
+import com.serwylo.beatgame.levels.achievements.loadAllAchievements
+import com.serwylo.beatgame.ui.*
+import kotlinx.coroutines.*
+
+abstract class WorldSelectorScreen(
+    private val game: BeatFeetGame,
+    private val headingId: String,
+    private val headingIcon: TextureRegion,
+    private val initialWorld: World
+): ScreenAdapter() {
+
+    protected val stage = makeStage()
+
+    protected val sprites = game.assets.getSprites()
+    protected val styles = game.assets.getStyles()
+    protected val skin = game.assets.getSkin()
+    protected val strings = game.assets.getStrings()
+
+    private val header = Container<Actor>()
+    private val body = Container<Actor>()
+
+    private val job = Job()
+    private val scope = CoroutineScope(Dispatchers.IO + job)
+
+    private var currentWorld: World = initialWorld
+
+    private var cachedWorlds: List<World>? = null
+
+    private suspend fun allWorlds(): List<World> {
+        return cachedWorlds ?: loadAllWorlds().also { newlyLoaded ->
+            cachedWorlds = newlyLoaded
+        }
+    }
+
+    init {
+
+        val container = Table().apply {
+            pad(UI_SPACE)
+            padTop(UI_SPACE * 2)
+        }
+
+        val scrollPane = ScrollPane(container, skin).apply {
+            setFillParent(true)
+            setScrollingDisabled(true, false)
+            setupOverscroll(width / 4, 30f, 200f)
+        }
+
+        stage.addActor(scrollPane)
+
+        container.add(
+            makeHeading(strings[headingId], headingIcon, styles, strings) {
+                game.showMenu()
+            }
+        ).top()
+        container.row()
+
+        container.add(header)
+        container.row()
+
+        container.add(body).expand().fillX().top()
+        container.row()
+
+        body.fill()
+
+        setupStage(initialWorld)
+
+    }
+
+    private fun setupStage(world: World) {
+        this.currentWorld = world
+
+        header.actor = makeWorldSelector(
+            strings,
+            styles,
+            world,
+            onPrevious = if (world === TheOriginalWorld) null else { -> onPreviousWorld(world) },
+            onNext = { onNextWorld(world) },
+        )
+
+        body.actor = makeBody(world)
+    }
+
+    protected abstract fun makeBody(world: World): Actor
+
+    private fun onPreviousWorld(currentWorld: World?) {
+        if (currentWorld === TheOriginalWorld) {
+            return
+        }
+
+        scope.launch {
+            val worlds = performSlowOperation {
+                allWorlds()
+            }
+            if (currentWorld == null) {
+                setupStage(worlds.last())
+            } else {
+                val currentIndex = worlds.indexOfFirst { it.getId() == currentWorld.getId() }
+                if (currentIndex > 0) {
+                    setupStage(worlds[currentIndex - 1])
+                }
+            }
+        }
+    }
+
+    private fun onNextWorld(currentWorld: World) {
+        scope.launch {
+            val worlds = performSlowOperation {
+                allWorlds()
+            }
+
+            val currentIndex = worlds.indexOfFirst { it.getId() == currentWorld.getId() }
+            if (currentIndex < worlds.size - 1) {
+                setupStage(worlds[currentIndex + 1])
+            } else {
+                showComingSoon(worlds)
+            }
+        }
+    }
+
+    private suspend fun <T>performSlowOperation(block: suspend () -> T): T = withContext(Dispatchers.IO) {
+        header.actor.addAction(
+            Actions.sequence(
+                Actions.delay(0.5f),
+                Actions.fadeOut(0.2f),
+            )
+        )
+
+        body.actor.addAction(
+            Actions.sequence(
+                Actions.delay(0.5f),
+                Actions.fadeOut(0.2f),
+                Actions.run {
+                    body.pad(UI_SPACE * 4)
+                    body.actor = Label(strings["loading-screen.loading"], styles.label.medium).also { label ->
+                        label.setAlignment(Align.center)
+                        label.addAction(Actions.fadeIn(0.2f))
+                    }
+                },
+            )
+        )
+
+        val result = block()
+
+        header.actor.clearActions()
+        body.actor.clearActions()
+        body.pad(0f)
+
+        header.actor.color.a = 1f
+        body.actor.color.a = 1f
+
+        result
+    }
+
+    private fun showComingSoon(knownWorlds: List<World>) {
+        header.actor = makeWorldSelector(strings, styles, null, onPrevious = {
+            onPreviousWorld(null)
+        })
+
+        body.actor = Table().apply {
+            pad(UI_SPACE)
+            padTop(UI_SPACE * 4)
+            add(
+                Label(strings["level-select.more-coming-soon.ask-for-recommendations"], styles.label.medium).also { label ->
+                    label.wrap = true
+                    label.setAlignment(Align.center)
+                }
+            ).pad(UI_SPACE).expandX().fill(0.75f, 0f).colspan(2)
+            row().pad(UI_SPACE)
+
+            add(
+                Label(strings["level-select.more-coming-soon.when-we-find-time"], styles.label.small).also { label ->
+                    label.wrap = true
+                    label.setAlignment(Align.center)
+                }
+            ).pad(UI_SPACE).expandX().fill(0.6f, 0f).colspan(2)
+            row().pad(UI_SPACE)
+
+            add(
+                makeButton(strings["level-select.more-coming-soon.suggest-a-song"], styles) {
+                    Gdx.net.openURI("https://github.com/beat-feet/beat-feet/issues/new?title=Song%20suggestion:%20&labels=song+suggestion&body=(PLEASE%20NOTE:%20This%20game%20is%20open%20source,%20and%20all%20songs%20included%20in%20it%20must%20be%20freely%20licensed,%20for%20example,%20CC-BY)")
+                }
+            ).pad(UI_SPACE).right()
+
+            add(
+                makeButton("Check for new levels", styles) {
+                    refreshLevels(knownWorlds)
+                }
+            ).pad(UI_SPACE).left()
+        }
+
+    }
+
+    private fun refreshLevels(knownWorlds: List<World>) {
+        scope.launch {
+            val newWorlds = performSlowOperation {
+                loadAllWorlds(forceUncached = true).also { newlyLoaded ->
+                    cachedWorlds = newlyLoaded
+                }
+            }
+
+            val oldLevelCount = knownWorlds.sumOf { it.getLevels().size }
+            val newLevelCount = newWorlds.sumOf { it.getLevels().size }
+
+            when {
+                newWorlds.size > knownWorlds.size -> setupStage(newWorlds[knownWorlds.size])
+                oldLevelCount != newLevelCount -> setupStage(newWorlds.last())
+                else -> showComingSoon(newWorlds)
+            }
+        }
+    }
+
+    override fun show() {
+
+        Gdx.input.setCatchKey(Input.Keys.BACK, true)
+        Gdx.input.inputProcessor = InputMultiplexer(stage, object : InputAdapter() {
+
+            override fun keyDown(keycode: Int): Boolean {
+                if (keycode == Input.Keys.ESCAPE || keycode == Input.Keys.BACK) {
+                    game.showMenu()
+                    return true
+                }
+
+                return false
+            }
+
+        })
+
+    }
+
+    override fun hide() {
+        Gdx.input.inputProcessor = null
+        Gdx.input.setCatchKey(Input.Keys.BACK, false)
+    }
+
+    override fun resize(width: Int, height: Int) {
+        stage.viewport.update(width, height, true)
+        setupStage(currentWorld)
+    }
+
+    override fun render(delta: Float) {
+
+        Gdx.gl.glClearColor(0f, 0f, 0f, 1f)
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT)
+
+        stage.act(delta)
+        stage.draw()
+
+    }
+
+    override fun dispose() {
+        stage.dispose()
+        scope.cancel()
+    }
+
+}
+

--- a/core/src/com/serwylo/beatgame/ui/scene2d.kt
+++ b/core/src/com/serwylo/beatgame/ui/scene2d.kt
@@ -84,7 +84,7 @@ fun makeWorldSelector(
 
         add(
             VerticalGroup().also { col ->
-                col.addActor(Label(currentWorld?.getLabel(strings) ?: "Coming soon...", styles.label.medium))
+                col.addActor(Label(currentWorld?.getLabel(strings) ?: strings["level-select.more-coming-soon.title"], styles.label.medium))
             }
         ).minWidth(UI_SPACE * 20)
 

--- a/core/src/com/serwylo/beatgame/ui/scene2d.kt
+++ b/core/src/com/serwylo/beatgame/ui/scene2d.kt
@@ -10,6 +10,8 @@ import com.badlogic.gdx.utils.I18NBundle
 import com.badlogic.gdx.utils.viewport.ExtendViewport
 import com.serwylo.beatgame.Assets
 import com.serwylo.beatgame.graphics.calcDensityScaleFactor
+import com.serwylo.beatgame.levels.TheOriginalWorld
+import com.serwylo.beatgame.levels.World
 
 fun makeStage() =
     Stage(ExtendViewport(UI_WIDTH, UI_HEIGHT))
@@ -67,6 +69,30 @@ fun makeHeading(title: String, icon: TextureRegion, styles: Assets.Styles, strin
         }
     }
 }
+
+fun makeWorldSelector(
+    strings: I18NBundle,
+    styles: Assets.Styles,
+    currentWorld: World?,
+    onPrevious: (() -> Unit)? = null,
+    onNext: (() -> Unit)? = null,
+) =
+    Table().apply {
+        add(
+            if (onPrevious == null) null else makeButton("<", styles, onPrevious)
+        ).width(UI_SPACE * 8).spaceRight(UI_SPACE * 2)
+
+        add(
+            VerticalGroup().also { col ->
+                col.addActor(Label(currentWorld?.getLabel(strings) ?: "Coming soon...", styles.label.medium))
+            }
+        ).minWidth(UI_SPACE * 20)
+
+        add(
+            if (onNext == null) null else makeButton(">", styles, onNext)
+        ).width(UI_SPACE * 8).spaceLeft(UI_SPACE * 2)
+    }
+
 
 val UI_WIDTH = 1024f / calcDensityScaleFactor()
 val UI_HEIGHT = 768f / calcDensityScaleFactor()

--- a/desktop/build.gradle
+++ b/desktop/build.gradle
@@ -1,4 +1,4 @@
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = ["../android/assets"]
 

--- a/desktop/src/com/serwylo/beatgame/desktop/BeatFeetGameForScreenshots.kt
+++ b/desktop/src/com/serwylo/beatgame/desktop/BeatFeetGameForScreenshots.kt
@@ -14,11 +14,9 @@ import com.serwylo.beatgame.levels.achievements.*
 import com.serwylo.beatgame.levels.clearAllHighScores
 import com.serwylo.beatgame.levels.saveHighScore
 import com.serwylo.beatgame.screens.*
-import java.io.File
-import java.util.*
 
 
-class BeatFeetGameForScreenshots(private val verbose: Boolean) : BeatFeetGame(DesktopPlatformListener(), verbose) {
+class BeatFeetGameForScreenshots(verbose: Boolean) : BeatFeetGame(DesktopPlatformListener(), verbose) {
 
     private val input = MockInput()
 
@@ -32,7 +30,7 @@ class BeatFeetGameForScreenshots(private val verbose: Boolean) : BeatFeetGame(De
         screenshot("01_main_menu.png")
 
         val level = Levels.Maintenance
-        val file = Gdx.files.internal("songs${File.separator}mp3${File.separator}${level.mp3Name}")
+        val file = level.getMp3File()
         val world = loadWorldFromMp3(file)
 
         val courtyardGame = PlatformGameScreen(this, world)

--- a/desktop/src/com/serwylo/beatgame/desktop/BeatFeetGameForScreenshots.kt
+++ b/desktop/src/com/serwylo/beatgame/desktop/BeatFeetGameForScreenshots.kt
@@ -7,12 +7,9 @@ import com.badlogic.gdx.graphics.PixmapIO
 import com.badlogic.gdx.utils.BufferUtils
 import com.badlogic.gdx.utils.ScreenUtils
 import com.serwylo.beatgame.BeatFeetGame
-import com.serwylo.beatgame.audio.loadWorldFromMp3
-import com.serwylo.beatgame.levels.Levels
-import com.serwylo.beatgame.levels.Score
+import com.serwylo.beatgame.audio.loadLevelDataFromMp3
+import com.serwylo.beatgame.levels.*
 import com.serwylo.beatgame.levels.achievements.*
-import com.serwylo.beatgame.levels.clearAllHighScores
-import com.serwylo.beatgame.levels.saveHighScore
 import com.serwylo.beatgame.screens.*
 
 
@@ -29,11 +26,10 @@ class BeatFeetGameForScreenshots(verbose: Boolean) : BeatFeetGame(DesktopPlatfor
         setScreen(MainMenuScreen(this))
         screenshot("01_main_menu.png")
 
-        val level = Levels.Maintenance
-        val file = level.getMp3File()
-        val world = loadWorldFromMp3(file)
+        val level = TheOriginalWorld.Maintenance
+        val levelData = loadLevelDataFromMp3(level.getMp3File())
 
-        val courtyardGame = PlatformGameScreen(this, world)
+        val courtyardGame = PlatformGameScreen(this, level, levelData)
         setScreen(courtyardGame)
 
         // Start the game by initiating a jump, then wait 16 seconds to the cool part of The Courtyard
@@ -58,23 +54,23 @@ class BeatFeetGameForScreenshots(verbose: Boolean) : BeatFeetGame(DesktopPlatfor
         timeStep(20f)
         screenshot("03_death.png")
 
-        setScreen(PlatformGameScreen(this, world))
+        setScreen(PlatformGameScreen(this, level, levelData))
         screenshot("04_in_game_2.png")
 
         clearAllHighScores()
         clearAllAchievements()
 
-        saveAchievements(Levels.TheLaundryRoom, listOf(DistanceX10(), DistanceX25(), DistanceX50(), DistanceX75(), ComboX5(), ComboX10(), ComboX25()))
-        saveAchievements(Levels.TheCourtyard, listOf(DistanceX10(), ComboX5()))
-        saveAchievements(Levels.Maintenance, listOf(DistanceX10(), DistanceX25(), DistanceX50(), ComboX5()))
-        saveAchievements(Levels.ForcingTheGamecard, listOf(DistanceX10(), DistanceX25(), ComboX5(), ComboX10()))
+        saveAchievements(TheOriginalWorld.TheLaundryRoom, listOf(DistanceX10(), DistanceX25(), DistanceX50(), DistanceX75(), ComboX5(), ComboX10(), ComboX25()))
+        saveAchievements(TheOriginalWorld.TheCourtyard, listOf(DistanceX10(), ComboX5()))
+        saveAchievements(TheOriginalWorld.Maintenance, listOf(DistanceX10(), DistanceX25(), DistanceX50(), ComboX5()))
+        saveAchievements(TheOriginalWorld.ForcingTheGamecard, listOf(DistanceX10(), DistanceX25(), ComboX5(), ComboX10()))
 
-        saveHighScore(Levels.TheLaundryRoom, Score(169986f, 0.95f))
-        saveHighScore(Levels.TheCourtyard, Score(7847f, 0.23f))
-        saveHighScore(Levels.Maintenance, Score(19634f, 0.66f))
-        saveHighScore(Levels.ForcingTheGamecard, Score(16948f, 0.25f))
+        saveHighScore(TheOriginalWorld.TheLaundryRoom, Score(169986f, 0.95f))
+        saveHighScore(TheOriginalWorld.TheCourtyard, Score(7847f, 0.23f))
+        saveHighScore(TheOriginalWorld.Maintenance, Score(19634f, 0.66f))
+        saveHighScore(TheOriginalWorld.ForcingTheGamecard, Score(16948f, 0.25f))
 
-        setScreen(LevelSelectScreen(this))
+        setScreen(LevelSelectScreen(this, TheOriginalWorld))
         screenshot("05_level_select.png")
 
         setScreen(AchievementsScreen(this))

--- a/fastlane/metadata/android/en-US/changelogs/22.txt
+++ b/fastlane/metadata/android/en-US/changelogs/22.txt
@@ -1,0 +1,7 @@
+🎶 New levels! 🎶 
+
+* 14 new levels from the awesome SpaceJacked sound track.
+* Get 50 achievements from the first original world to start unlocking these levels.
+* Code changes to make it easier to add new levels.
+
+Have any recommendations for more great, freely licensed music? Suggest it on GitHub.

--- a/song-extract/build.gradle
+++ b/song-extract/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "kotlin"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 project.ext.mainClassName = "com.serwylo.beatgame.bin.SongExtractLauncherKt"

--- a/song-extract/src/com/serwylo/beatgame/SongExtractApplication.kt
+++ b/song-extract/src/com/serwylo/beatgame/SongExtractApplication.kt
@@ -3,8 +3,8 @@ package com.serwylo.beatgame.desktop
 import com.badlogic.gdx.Application
 import com.badlogic.gdx.ApplicationAdapter
 import com.badlogic.gdx.Gdx
-import com.serwylo.beatgame.audio.loadFromDisk
-import com.serwylo.beatgame.audio.saveWorldToDisk
+import com.serwylo.beatgame.audio.loadLevelDataFromDisk
+import com.serwylo.beatgame.audio.saveLevelDataToDisk
 import java.io.File
 
 class SongExtract(private var arg: Array<String>): ApplicationAdapter() {
@@ -51,8 +51,8 @@ class SongExtract(private var arg: Array<String>): ApplicationAdapter() {
 
         Gdx.app.log(TAG, "Processing ${mp3File.name}, writing to ${outPath}.")
 
-        val world = loadFromDisk(Gdx.files.absolute(mp3File.path))
-        saveWorldToDisk(outFile, world)
+        val world = loadLevelDataFromDisk(Gdx.files.absolute(mp3File.path))
+        saveLevelDataToDisk(outFile, world)
 
     }
 

--- a/texture-packer/build.gradle
+++ b/texture-packer/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "kotlin"
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 project.ext.mainClassName = "com.serwylo.beatgame.bin.TexturePackerKt"


### PR DESCRIPTION
Downloads metadata about levels from https://beat-feet.github.io/beat-feet-levels/worlds.json, and then when playing a level for the first time, download both the mp3 and the level data from here too.

Required adding the notion of "Worlds" (including built in worlds like the original one, along with remote worlds loaded from the net). This in turn needed changes to level select screens, as well as the achievements and about/credits screen.