### PR TITLE
Enable Basque translation + Bump for release v0.14.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.serwylo.beatgame"
         minSdkVersion 14
         targetSdkVersion 33
-        versionCode 29
-        versionName "0.14.7"
+        versionCode 30
+        versionName "0.14.8"
     }
     buildTypes {
         release {

--- a/core/src/com/serwylo/beatgame/Assets.kt
+++ b/core/src/com/serwylo/beatgame/Assets.kt
@@ -378,6 +378,7 @@ class Assets(private val locale: Locale) {
             "en" to Font.KENNEY,
             "eo" to Font.KENNEY,
             "es" to Font.KENNEY,
+            "eu" to Font.KENNEY,
             // "fa", // Glyphs and RTL currently not supported.
             "fr" to Font.KENNEY,
             "hu" to Font.NOTO_MONO, // The character ő and perhaps others are not supported with Kenney fonts.

--- a/fastlane/metadata/android/en-US/changelogs/30.txt
+++ b/fastlane/metadata/android/en-US/changelogs/30.txt
@@ -1,0 +1,4 @@
+More translations!
+* Basque (thanks @josuigoa)
+
+Want to see this game in your language? Please join us on Weblate to contribute a translation.


### PR DESCRIPTION
Wiki says that the Basque language uses the latin alphabet, plus the `ñ` character. Given the translation here doesn't yet use that character, just use the built-in Kenney fonts.